### PR TITLE
refactor: Rename repository to dotnet-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# appium-dotnet-driver
+# dotnet-client
 
 [![NuGet Badge](https://buildstats.info/nuget/Appium.Webdriver)](https://www.nuget.org/packages/Appium.Webdriver/)
 [![Build Status](https://dev.azure.com/AppiumCI/dotnet-client/_apis/build/status/appium.appium-dotnet-driver?branchName=master)](https://dev.azure.com/AppiumCI/dotnet-client/_build/latest?definitionId=13&branchName=master)

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -5,10 +5,10 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RootNamespace>OpenQA.Selenium</RootNamespace>
     <Company>Appium Commiters</Company>
-    <Product>Appium-Dotnet-Driver</Product>
+    <Product>Dotnet-Client</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Copyright>Copyright © 2020</Copyright>
+    <Copyright>Copyright © 2022</Copyright>
     <PackageProjectUrl>https://github.com/appium/dotnet-client</PackageProjectUrl>
     <RepositoryUrl>https://github.com/appium/dotnet-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -9,8 +9,8 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright © 2020</Copyright>
-    <PackageProjectUrl>https://github.com/appium/appium-dotnet-driver</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/appium/appium-dotnet-driver</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/appium/dotnet-client</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/appium/dotnet-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/test/integration/IOS/ClipboardTest.cs
+++ b/test/integration/IOS/ClipboardTest.cs
@@ -48,7 +48,7 @@ namespace Appium.Net.Integration.Tests.IOS
         [Test]
         public void WhenSetClipboardContentTypeIsUrl_GetClipboardShouldReturnEncodedBase64String()
         {
-            const string urlString = "https://github.com/appium/appium-dotnet-driver";
+            const string urlString = "https://github.com/appium/dotnet-client";
             var base64String = Convert.ToBase64String(Encoding.UTF8.GetBytes(urlString));
             _driver.SetClipboard(ClipboardContentType.Url, base64String);
 
@@ -59,7 +59,7 @@ namespace Appium.Net.Integration.Tests.IOS
         [Test]
         public void WhenSetClipboardUrl_GetClipboardUrlShouldReturnUrl()
         {
-            const string urlString = "https://github.com/appium/appium-dotnet-driver";
+            const string urlString = "https://github.com/appium/dotnet-client";
             _driver.SetClipboardUrl(urlString);
 
             Assert.That(() => _driver.GetClipboardUrl(), Does.Match(urlString));

--- a/test/integration/helpers/Apps.cs
+++ b/test/integration/helpers/Apps.cs
@@ -20,12 +20,12 @@ namespace Appium.Net.Integration.Tests.helpers
                 {
                     _testApps = new Dictionary<string, string>
                     {
-                        {iosTestApp, "https://github.com/appium/appium-dotnet-driver/blob/master/test/integration/apps/archives/TestApp.app.zip?raw=true"},
-                        {intentApp, "https://github.com/appium/appium-dotnet-driver/blob/master/test/integration/apps/archives/IntentExample.zip?raw=true"},
-                        {iosWebviewApp, "https://github.com/appium/appium-dotnet-driver/blob/master/test/integration/apps/archives/WebViewApp.app.zip?raw=true"},
-                        {iosUICatalogApp, "https://github.com/appium/appium-dotnet-driver/blob/master/test/integration/apps/archives/UICatalog.app.zip?raw=true"},
-                        {androidApiDemos, "https://github.com/appium/appium-dotnet-driver/blob/master/test/integration/apps/archives/ApiDemos-debug.zip?raw=true"},
-                        {vodqaApp, "https://github.com/appium/appium-dotnet-driver/blob/master/test/integration/apps/archives/vodqa.zip?raw=true"}
+                        {iosTestApp, "https://github.com/appium/dotnet-client/blob/master/test/integration/apps/archives/TestApp.app.zip?raw=true"},
+                        {intentApp, "https://github.com/appium/dotnet-client/blob/master/test/integration/apps/archives/IntentExample.zip?raw=true"},
+                        {iosWebviewApp, "https://github.com/appium/dotnet-client/blob/master/test/integration/apps/archives/WebViewApp.app.zip?raw=true"},
+                        {iosUICatalogApp, "https://github.com/appium/dotnet-client/blob/master/test/integration/apps/archives/UICatalog.app.zip?raw=true"},
+                        {androidApiDemos, "https://github.com/appium/dotnet-client/blob/master/test/integration/apps/archives/ApiDemos-debug.zip?raw=true"},
+                        {vodqaApp, "https://github.com/appium/dotnet-client/blob/master/test/integration/apps/archives/vodqa.zip?raw=true"}
                     };
                 }
                 else


### PR DESCRIPTION
In case we would like to rename the repo to match the other clients in the appium project, this is a good place to start.
As discussed with @akinsolb on slack

## Change list

Please provide briefly described change list which are you going to propose. 
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [x] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
