### PR TITLE
feat: added the ability to activate the app with timeout

### DIFF
--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -241,6 +241,12 @@ namespace OpenQA.Selenium.Appium
 
         public void ActivateApp(string appId) =>
             Execute(AppiumDriverCommand.ActivateApp, AppiumCommandExecutionHelper.PrepareArgument("appId", appId));
+        
+        public void ActivateApp(string appId, TimeSpan timeout) =>
+            Execute(AppiumDriverCommand.ActivateApp,
+                    AppiumCommandExecutionHelper.PrepareArguments(new string[] {"appId", "options"},
+                        new object[]
+                            {appId, new Dictionary<string, object>() {{"timeout", (long) timeout.TotalMilliseconds}}}));
 
         public bool TerminateApp(string appId) =>
             Convert.ToBoolean(Execute(AppiumDriverCommand.TerminateApp,

--- a/test/integration/Android/Device/AppTests.cs
+++ b/test/integration/Android/Device/AppTests.cs
@@ -43,6 +43,16 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
             //Verify the expected app was activated
             Assert.DoesNotThrow(() => _driver.FindElementById(IntentAppElement));
         }
+        
+        [Test]
+        public void CanActivateAppWithTimeoutTest()
+        {
+            //Activate an app to foreground
+            Assert.DoesNotThrow(() => _driver.ActivateApp(IntentAppPackageName, TimeSpan.FromSeconds(20)));
+
+            //Verify the expected app was activated
+            Assert.DoesNotThrow(() => _driver.FindElementById(IntentAppElement));
+        }
 
         [Test]
         public void CanActivateAppFromBackgroundTest()

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -45,7 +45,17 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             //Verify the expected app was activated
             Assert.DoesNotThrow(() => _driver.FindElementByAccessibilityId(IosTestAppElement));
         }
+        
+        [Test]
+        public void CanActivateAppWithTimeoutTest()
+        {
+            //Activate an app to foreground
+            Assert.DoesNotThrow(() => _driver.ActivateApp(IosTestAppBundleId, TimeSpan.FromSeconds(20)));
 
+            //Verify the expected app was activated
+            Assert.DoesNotThrow(() => _driver.FindElementById(IosTestAppBundleId));
+        }
+        
         [Test]
         public void CanActivateViaScriptAppTest()
         {


### PR DESCRIPTION
## Change list
Adding timeout to the activate app function
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

sometimes on slower emulators, activating the app requires more time then provided by default, this change solves it.

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
