### PR TITLE
test: Fix AppTests due to IntentApp removal

### DIFF
--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -33,7 +33,11 @@
     <DocumentationFile>Appium.Net.xml</DocumentationFile>
   </PropertyGroup>
 
-	<ItemGroup>
+  <PropertyGroup>
+	<LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
     <None Include="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/test/integration/Android/Device/AppTests.cs
+++ b/test/integration/Android/Device/AppTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
-using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 
@@ -11,9 +10,7 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
     {
         private AppiumDriver _driver;
         private AppiumOptions _androidOptions;
-        private const string IntentAppPackageName = "com.prgguru.android";
         private const string ApiDemosPackageName = "io.appium.android.apis";
-        private const string IntentAppElement = "com.prgguru.android:id/button1";
         private const string ApiDemoElement = "Accessibility";
 
         [OneTimeSetUp]
@@ -38,20 +35,22 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         public void CanActivateAppTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow(() => _driver.ActivateApp(IntentAppPackageName));
+            Assert.DoesNotThrow(() => _driver.ActivateApp(ApiDemosPackageName));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.Id(IntentAppElement)));
+            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
         }
 
         [Test]
         public void CanActivateAppFromBackgroundTest()
         {
             //Activate an app to foreground
-            _driver.ActivateApp(IntentAppPackageName);
+            _driver.ActivateApp(ApiDemosPackageName);
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.Id(IntentAppElement)));
+            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
+
+            Assert.DoesNotThrow(() => _driver.BackgroundApp());
 
             //Activates Test App to foreground from background
             Assert.DoesNotThrow(() => _driver.ActivateApp(ApiDemosPackageName));


### PR DESCRIPTION
## Change list

following commit https://github.com/appium/dotnet-client/commit/6294052fbe38e1a4f6bfdda61312326e397ed8e2 , AppTests can't pass since IntentApp was removed.
I made some adjustments and cleaned the obsolete strings 
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [X] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
