### PR TITLE
docs: add Appium server compatibility for v5.x section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ all the functionalities of the regular driver, but add Appium specific methods o
 > In case you would like to use this client with Selenium 4.0 and above, please use the latest beta version(v5.0.0). <br/>
 > We are well aware this project is not actively maintained, therefore any contributors are more than welcomed to assist with this project.
 
+## Appium server compatibility  
+
+In case you are using the latest beta version v5.x, please be aware you will have to upgrade your appium server to 2.x. due to a breaking change on the default server base path. <br/>
+Regardless it's highly recommended you move to appium 2.x since appium 1.x is no longet maintained. <br/>
+For more details about how to migrate to 2.x, see the following link : [appium 2.x migrating](https://appium.github.io/appium/docs/en/2.0/guides/migrating-1-to-2/)
+
 ## NuGet
 
 NuGet Package: [](http://www.nuget.org/packages/Appium.WebDriver/)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ all the functionalities of the regular driver, but add Appium specific methods o
 > In case you would like to use this client with Selenium 4.0 and above, please use the latest beta version(v5.0.0). <br/>
 > We are well aware this project is not actively maintained, therefore any contributors are more than welcomed to assist with this project.
 
-## Appium server compatibility  
+## Appium server compatibility for v5.x 
 
-In case you are using the latest beta version v5.x, please be aware you will have to upgrade your appium server to 2.x. due to a breaking change on the default server base path. <br/>
-Regardless it's highly recommended you move to appium 2.x since appium 1.x is no longet maintained. <br/>
+In case you are using the latest beta client v5.x please be aware you will either have to upgrade your appium server to 2.x or add the base-path argument:
+`appium --base-path=/wd/hub`, due to a breaking change on the default server base path. <br/>
+Regardless, it's highly recommended you move to appium 2.x since appium 1.x is no longer maintained. <br/>
 For more details about how to migrate to 2.x, see the following link : [appium 2.x migrating](https://appium.github.io/appium/docs/en/2.0/guides/migrating-1-to-2/)
 
 ## NuGet


### PR DESCRIPTION
## Change list

It seems like some people are not aware of the changes made on the 5.x version that requires them to either update to appium server 2.x or add the base-path argument when starting the server.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [x] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
