### PR TITLE
fix: Add missing AutomationName option for ClickElementTest

### DIFF
--- a/test/integration/Windows/ClickElementTest.cs
+++ b/test/integration/Windows/ClickElementTest.cs
@@ -29,6 +29,7 @@ namespace Appium.Net.Integration.Tests.Windows
         public void BeforeAll()
         {
             var appCapabilities = new AppiumOptions();
+            appCapabilities.AutomationName = "Windows";
             appCapabilities.App = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App";
             appCapabilities.DeviceName = "WindowsPC";
             appCapabilities.PlatformName = "Windows";


### PR DESCRIPTION
## Change list

With the new appium 2.x server AutomationName is mandatory. 
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
