### PR TITLE
test: add missing AutomationName option

### DIFF
--- a/test/integration/Android/Device/BrowserTests.cs
+++ b/test/integration/Android/Device/BrowserTests.cs
@@ -16,6 +16,7 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         {
             _androidOptions = new AppiumOptions();
             _androidOptions.BrowserName = "Chrome";
+            _androidOptions.AutomationName = "UiAutomator2";
 
             _driver = new AndroidDriver(
                 Env.ServerIsLocal() ? AppiumServers.LocalServiceUri : AppiumServers.RemoteServerUri,
@@ -26,7 +27,7 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         [OneTimeTearDown]
         public void TearDown()
         {
-            _driver.Dispose();
+            _driver?.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
## Change list

BrowserTests is missing the newly required option: AutomationName for appium 2.x server
add as well small validation to dispose driver just in case it's not null.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
