### PR TITLE
chore: Deprecate legacy app management helpers

### DIFF
--- a/src/Appium.Net/Appium/AppiumCommand.cs
+++ b/src/Appium.Net/Appium/AppiumCommand.cs
@@ -114,12 +114,18 @@ namespace OpenQA.Selenium.Appium
                 "/session/{sessionId}/appium/getPerformanceData"),
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.GetPerformanceDataTypes,
                 "/session/{sessionId}/appium/performanceData/types"),
+
+            #region (Deprecated) legacy app management
+
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.LaunchApp,
                 "/session/{sessionId}/appium/app/launch"),
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.CloseApp,
                 "/session/{sessionId}/appium/app/close"),
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.ResetApp,
                 "/session/{sessionId}/appium/app/reset"),
+
+            #endregion (Deprecated) legacy app management
+
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.BackgroundApp,
                 "/session/{sessionId}/appium/app/background"),
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.EndTestCoverage,
@@ -144,8 +150,6 @@ namespace OpenQA.Selenium.Appium
                 "/session/{sessionId}/appium/device/finger_print"),
 
             #endregion Driver Commands
-
-            
             
             #region (Deprecated) Touch Commands 
             // TODO: Remove this region once we deprecate the touch actions

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -178,11 +178,11 @@ namespace OpenQA.Selenium.Appium
         public void PushFile(string pathOnDevice, FileInfo file) =>
             AppiumCommandExecutionHelper.PushFile(this, pathOnDevice, file);
 
-        [Obsolete("Legacy app management helpers are deprecated, please use ActivateApp instead")]
+        [Obsolete("The LaunchApp API is deprecated and will be removed in future versions. Please use ActivateApp instead \r\n See https://github.com/appium/appium/issues/15807")]
         public void LaunchApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.LaunchApp);
-        [Obsolete("Legacy app management helpers are deprecated, please use TerminateApp instead")]
+        [Obsolete("The CloseApp API is deprecated and will be removed in future versions. Please use TerminateApp instead \r\n See https://github.com/appium/appium/issues/15807")]
         public void CloseApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.CloseApp);
-        [Obsolete("Legacy app management helpers are deprecated , please use W3C actions instead")]
+        [Obsolete("The ResetApp API is deprecated and will be removed in future versions. Please use TerminateApp & ActivateApp instead \r\n See https://github.com/appium/appium/issues/15807")]
         public void ResetApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.ResetApp);
 
         public void FingerPrint(int fingerprintId) =>

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -178,10 +178,11 @@ namespace OpenQA.Selenium.Appium
         public void PushFile(string pathOnDevice, FileInfo file) =>
             AppiumCommandExecutionHelper.PushFile(this, pathOnDevice, file);
 
+        [Obsolete("Legacy app management helpers are deprecated, please use ActivateApp instead")]
         public void LaunchApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.LaunchApp);
-
+        [Obsolete("Legacy app management helpers are deprecated, please use TerminateApp instead")]
         public void CloseApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.CloseApp);
-
+        [Obsolete("Legacy app management helpers are deprecated , please use W3C actions instead")]
         public void ResetApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.ResetApp);
 
         public void FingerPrint(int fingerprintId) =>

--- a/src/Appium.Net/Appium/AppiumDriverCommand.cs
+++ b/src/Appium.Net/Appium/AppiumDriverCommand.cs
@@ -143,6 +143,8 @@ namespace OpenQA.Selenium.Appium
         /// </summary>
         public const string ToggleLocationServices = "toggleLocationServices";
 
+        #region (Deprecated) legacy app management
+
         /// <summary>
         /// Launch App Command.
         /// </summary>
@@ -157,6 +159,8 @@ namespace OpenQA.Selenium.Appium
         /// Reset App Command.
         /// </summary>
         public const string ResetApp = "resetApp";
+
+        #endregion (Deprecated) legacy app management
 
         /// <summary>
         ///  Background App Command.

--- a/src/Appium.Net/Appium/Windows/WindowsDriver.cs
+++ b/src/Appium.Net/Appium/Windows/WindowsDriver.cs
@@ -141,5 +141,19 @@ namespace OpenQA.Selenium.Appium.Windows
 
         public void LongPressKeyCode(int keyCode, int metastate = -1) =>
             AppiumCommandExecutionHelper.LongPressKeyCode(this, keyCode, metastate);
+
+        #region App management
+
+        public new void LaunchApp()
+        {
+            ((IExecuteMethod)this).Execute(AppiumDriverCommand.LaunchApp);
+        }
+
+        public new void CloseApp()
+        {
+            ((IExecuteMethod)this).Execute(AppiumDriverCommand.CloseApp);
+        }
+
+        #endregion App management
     }
 }

--- a/test/integration/Android/ActivityTest.cs
+++ b/test/integration/Android/ActivityTest.cs
@@ -9,6 +9,7 @@ namespace Appium.Net.Integration.Tests.Android
     {
         private AndroidDriver _driver;
         private const string ContactsActivity = ".activities.PeopleActivity";
+        private const string AppId = "io.appium.android.apis";
 
         [OneTimeSetUp]
         public void BeforeAll()
@@ -20,29 +21,29 @@ namespace Appium.Net.Integration.Tests.Android
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;
-            _driver.CloseApp();
+            _driver.TerminateApp(AppId);
         }
 
         [SetUp]
         public void SetUp()
         {
-            _driver?.LaunchApp();
+            _driver?.ActivateApp(AppId);
         }
 
         [TearDown]
         public void TearDowwn()
         {
-            _driver?.CloseApp();
+            _driver.TerminateApp(AppId);
         }
 
         [Test]
         public void StartActivityInThisAppTestCase()
         {
-            _driver.StartActivity("io.appium.android.apis", ".ApiDemos");
+            _driver.StartActivity(AppId, ".ApiDemos");
 
             Assert.AreEqual(_driver.CurrentActivity, ".ApiDemos");
 
-            _driver.StartActivity("io.appium.android.apis", ".accessibility.AccessibilityNodeProviderActivity");
+            _driver.StartActivity(AppId, ".accessibility.AccessibilityNodeProviderActivity");
 
             Assert.AreEqual(_driver.CurrentActivity, ".accessibility.AccessibilityNodeProviderActivity");
         }
@@ -50,11 +51,11 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void StartActivityWithWaitingAppTestCase()
         {
-            _driver.StartActivity("io.appium.android.apis", ".ApiDemos", "io.appium.android.apis", ".ApiDemos");
+            _driver.StartActivity(AppId, ".ApiDemos", AppId, ".ApiDemos");
 
             Assert.AreEqual(_driver.CurrentActivity, ".ApiDemos");
 
-            _driver.StartActivity("io.appium.android.apis", ".accessibility.AccessibilityNodeProviderActivity",
+            _driver.StartActivity(AppId, ".accessibility.AccessibilityNodeProviderActivity",
                 "io.appium.android.apis", ".accessibility.AccessibilityNodeProviderActivity");
 
             Assert.AreEqual(_driver.CurrentActivity, ".accessibility.AccessibilityNodeProviderActivity");
@@ -63,7 +64,7 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void StartActivityInNewAppTestCase()
         {
-            _driver.StartActivity("io.appium.android.apis", ".ApiDemos");
+            _driver.StartActivity(AppId, ".ApiDemos");
 
             Assert.AreEqual(_driver.CurrentActivity, ".ApiDemos");
 
@@ -77,7 +78,7 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void StartActivityInNewAppTestCaseWithoutClosingApp()
         {
-            _driver.StartActivity("io.appium.android.apis", ".accessibility.AccessibilityNodeProviderActivity");
+            _driver.StartActivity(AppId, ".accessibility.AccessibilityNodeProviderActivity");
 
             Assert.AreEqual(_driver.CurrentActivity, ".accessibility.AccessibilityNodeProviderActivity");
 


### PR DESCRIPTION
## Change list

As mentioned in https://github.com/appium/appium/issues/15807, these methods will not be supported anymore.
Related item:
https://github.com/appium/dotnet-client/issues/562
For now, I updated only one Integration test to use the more standard Appium session management, more will follow.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
