### PR TITLE
chore: add deprecations for SetImmediateValue & ReplaceValue methods

### DIFF
--- a/src/Appium.Net/Appium/Android/AndroidCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/Android/AndroidCommandExecutionHelper.cs
@@ -176,6 +176,7 @@ namespace OpenQA.Selenium.Appium.Android
         public static void Unlock(IExecuteMethod executeMethod) =>
             executeMethod.Execute(AppiumDriverCommand.UnlockDevice);
 
+        [Obsolete("The ReplaceValue method is deprecated and will be removed in future versions. Please use the following command extensions: 'mobile: replaceElementValue' instead \r\n See https://github.com/appium/appium-uiautomator2-driver#mobile-replaceelementvalue")]
         public static void ReplaceValue(IExecuteMethod executeMethod, string elementId, string value) =>
             executeMethod.Execute(AppiumDriverCommand.ReplaceValue,
                 new Dictionary<string, object>()

--- a/src/Appium.Net/Appium/AppiumCommand.cs
+++ b/src/Appium.Net/Appium/AppiumCommand.cs
@@ -199,14 +199,14 @@ namespace OpenQA.Selenium.Appium
 
             #endregion Input Method (IME)
 
-            #region Input value
+            #region (Deprecated) Input value
 
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.ReplaceValue,
                 "/session/{sessionId}/appium/element/{id}/replace_value"),
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.SetValue,
                 "/session/{sessionId}/appium/element/{id}/value"),
 
-            #endregion Input value
+            #endregion (Deprecated) Input value
 
             #region SeassionData
 

--- a/src/Appium.Net/Appium/AppiumDriverCommand.cs
+++ b/src/Appium.Net/Appium/AppiumDriverCommand.cs
@@ -353,10 +353,13 @@ namespace OpenQA.Selenium.Appium
         /// </summary>
         public const string FingerPrint = "fingerPrint";
 
+        #region (Deprecated) Input value
 
         public const string ReplaceValue = "replaceValue";
 
         public const string SetValue = "setValue";
+
+        #endregion (Deprecated) Input value
 
         public const string GetDeviceTime = "getDeviceTime";
 

--- a/src/Appium.Net/Appium/AppiumElement.cs
+++ b/src/Appium.Net/Appium/AppiumElement.cs
@@ -200,9 +200,11 @@ namespace OpenQA.Selenium.Appium
 
         #endregion
 
+        [Obsolete("The SetImmediateValue method is deprecated and will be removed in future versions. Please use 'SendKeys' instead.")]
         public void SetImmediateValue(string value) => Execute(AppiumDriverCommand.SetValue,
             new Dictionary<string, object>() { ["id"] = Id, ["value"] = value });
 
+        [Obsolete("The ReplaceValue method is deprecated and will be removed in future versions. Please use the following command extensions: 'mobile: replaceElementValue' instead \r\n See https://github.com/appium/appium-uiautomator2-driver#mobile-replaceelementvalue")]
         public void ReplaceValue(string value) => Execute(AppiumDriverCommand.ReplaceValue,
             new Dictionary<string, object>() { ["id"] = Id, ["value"] = value });
 

--- a/src/Appium.Net/Appium/Tizen/TizenCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/Tizen/TizenCommandExecutionHelper.cs
@@ -13,12 +13,14 @@
 //limitations under the License.
 
 using OpenQA.Selenium.Appium.Interfaces;
+using System;
 using System.Collections.Generic;
 
 namespace OpenQA.Selenium.Appium.Tizen
 {
     public sealed class TizenCommandExecutionHelper : AppiumCommandExecutionHelper
     {
+        [Obsolete("The ReplaceValue method is deprecated and will be removed in future versions. Please use the following command extensions: 'mobile: replaceElementValue' instead \r\n See https://github.com/appium/appium-uiautomator2-driver#mobile-replaceelementvalue")]
         public static void ReplaceValue(IExecuteMethod executeMethod, string elementId, string value) =>
             executeMethod.Execute(AppiumDriverCommand.ReplaceValue,
                 new Dictionary<string, object>()

--- a/test/integration/Android/ElementTest.cs
+++ b/test/integration/Android/ElementTest.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Android.UiAutomator;
+using System.Collections.Generic;
 
 namespace Appium.Net.Integration.Tests.Android
 {
@@ -96,25 +97,12 @@ namespace Appium.Net.Integration.Tests.Android
 
             Assert.AreEqual(originalValue, editElement.Text);
 
-            editElement.ReplaceValue(replacedValue);
+            _driver.ExecuteScript("mobile: replaceElementValue",
+                new Dictionary<string, string> { { "elementId", editElement.Id } , { "text", replacedValue } });
 
             Assert.AreEqual(replacedValue, editElement.Text);
         }
 
-        [Test]
-        public void SetImmediateValueTest()
-        {
-            var value = "new value";
-
-            _driver.StartActivity("io.appium.android.apis", ".view.Controls1");
-
-            var editElement =
-                _driver.FindElement(MobileBy.AndroidUIAutomator("resourceId(\"io.appium.android.apis:id/edit\")"));
-
-            editElement.SetImmediateValue(value);
-
-            Assert.AreEqual(value, editElement.Text);
-        }
 
         [Test]
         public void ScrollingToSubElement()

--- a/test/integration/IOS/ElementTest.cs
+++ b/test/integration/IOS/ElementTest.cs
@@ -48,12 +48,5 @@ namespace Appium.Net.Integration.Tests.IOS
                 1);
         }
 
-        [Test]
-        public void SetImmediateValueTest()
-        {
-            var slider = _driver.FindElement(MobileBy.ClassName("UIASlider"));
-            slider.SetImmediateValue("0%");
-            Assert.AreEqual("0%", slider.GetAttribute("value"));
-        }
     }
 }


### PR DESCRIPTION
## Change list

- Added deprecations messages for SetImmediateValue & ReplaceValue methods
- Added Deprecated region for Input value in AppiumDriverCommand
- Cleanup SetImmediateValueTests for both iOS and Android
- Update ReplaceValueTest in Android to use 'mobile: replaceElementValue'

## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Since replaceValue & setValue sends "value", but since the original setValue API requires "text" in W3C we receive an error.
