### PR TITLE
fix: Add new methods for extended element finding in AppiumElement

### DIFF
--- a/src/Appium.Net/Appium/AppiumElement.cs
+++ b/src/Appium.Net/Appium/AppiumElement.cs
@@ -220,10 +220,30 @@ namespace OpenQA.Selenium.Appium
 
         IReadOnlyCollection<AppiumElement> IFindsByFluentSelector<AppiumElement>.FindElements(string selector, string value)
         {
-            return ConvertToExtendedWebElementCollection(base.FindElements(selector, value));
+            return ConvertToAppiumElementCollection(base.FindElements(selector, value));
         }
 
-        internal static ReadOnlyCollection<AppiumElement> ConvertToExtendedWebElementCollection(IEnumerable collection)
+        /// <summary>
+        /// Finds the first element that matches the specified <paramref name="by"/> selector and returns it as an <see cref="AppiumElement"/>.
+        /// </summary>
+        /// <param name="by">The <see cref="By"/> selector used to locate the element.</param>
+        /// <returns>The first <see cref="AppiumElement"/> that matches the <paramref name="by"/> selector.</returns>
+        public new AppiumElement FindElement(By by)
+        {
+            return (AppiumElement)base.FindElement(by);
+        }
+
+        /// <summary>
+        /// Finds all elements that match the specified <paramref name="by"/> selector and returns them as a read-only collection of <see cref="AppiumElement"/>.
+        /// </summary>
+        /// <param name="by">The <see cref="By"/> selector used to locate the elements.</param>
+        /// <returns>A read-only collection of <see cref="AppiumElement"/> objects matching the <paramref name="by"/> selector.</returns>
+        public new ReadOnlyCollection<AppiumElement> FindElements(By by)
+        {
+            return ConvertToAppiumElementCollection(base.FindElements(by));
+        }
+
+        internal static ReadOnlyCollection<AppiumElement> ConvertToAppiumElementCollection(IEnumerable collection)
         {
             return collection.Cast<AppiumElement>().ToList().AsReadOnly();
         }

--- a/test/integration/Android/ElementTest.cs
+++ b/test/integration/Android/ElementTest.cs
@@ -126,6 +126,22 @@ namespace Appium.Net.Integration.Tests.Android
             Assert.NotNull(radioGroup.Location);
         }
 
+        [Test]
+        public void FindAppiumElementUsingNestedElement()
+        {
+            var myElement = _driver.FindElement(MobileBy.Id("android:id/content"));
+            AppiumElement nestedElement = myElement.FindElement(By.Id("android:id/text1"));
+            Assert.NotNull(nestedElement);
+        }
+
+        [Test]
+        public void FindAppiumElementsListUsingNestedElement()
+        {
+            var myElement = _driver.FindElement(MobileBy.Id("android:id/content"));
+            IList<AppiumElement> myDerivedElements = myElement.FindElements(By.Id("android:id/text1"));
+            Assert.AreNotEqual(myDerivedElements.Count,0);
+        }
+
         [OneTimeTearDown]
         public void AfterAll()
         {


### PR DESCRIPTION
## List of changes

Add new methods for extended element finding and rename utility method in AppiumElement class

- Add `FindElement` method to return AppiumElement
- Add `FindElements` method to return ReadOnlyCollection<AppiumElement>
- Rename `ConvertToExtendedWebElementCollection` to `ConvertToAppiumElementCollection`

These methods and the renaming improve compatibility with AppiumElement types and enhance element-finding capabilities.

Closing https://github.com/appium/dotnet-client/issues/573
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
