### PR TITLE
test: remove obsolete ByIosUIAutomation and add new test in ios/AlertTests

### DIFF
--- a/test/integration/IOS/AlertTests.cs
+++ b/test/integration/IOS/AlertTests.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium.iOS;
 
 namespace Appium.Net.Integration.Tests.IOS
 {
-    public class AlertTest
+    public class AlertTests
     {
         private AppiumDriver _driver;
 
@@ -32,17 +32,26 @@ namespace Appium.Net.Integration.Tests.IOS
         [Test]
         public void AcceptAlertTest()
         {
-            _driver.FindElement(new ByIosUIAutomation(".elements().withName(\"show alert\")")).Click();
-            Thread.Sleep(10000);
+            _driver.FindElement(MobileBy.IosNSPredicate("label == 'show alert'")).Click();
+            Thread.Sleep(5000);
             _driver.SwitchTo().Alert().Accept();
         }
 
         [Test]
         public void DismissAlertTest()
         {
-            _driver.FindElement(new ByIosUIAutomation(".elements().withName(\"show alert\")")).Click();
-            Thread.Sleep(10000);
+            _driver.FindElement(MobileBy.IosNSPredicate("label == 'show alert'")).Click();
+            Thread.Sleep(5000);
             _driver.SwitchTo().Alert().Dismiss();
+        }
+
+        [Test]
+        public void TextAlertTest()
+        {
+            _driver.FindElement(MobileBy.IosNSPredicate("label == 'show alert'")).Click();
+            Thread.Sleep(500);
+            string alertText = _driver.SwitchTo().Alert().Text;
+            Assert.AreEqual("Cool title\r\nthis alert is so cool.", alertText);
         }
     }
 }


### PR DESCRIPTION
## List of changes

- ByIosUIAutomation  selector is obsolete, before I remove it completely I prefer to fix current tests 
- added a new test for alerts along the way 
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
