### PR TITLE
fix: use blob/main instead of tree/master for apps urls

### DIFF
--- a/test/integration/helpers/Apps.cs
+++ b/test/integration/helpers/Apps.cs
@@ -20,11 +20,11 @@ namespace Appium.Net.Integration.Tests.helpers
                 {
                     _testApps = new Dictionary<string, string>
                     {
-                        {iosTestApp, "https://github.com/appium/dotnet-client/tree/master/test/integration/apps/archives/TestApp.app.zip?raw=true"},
-                        {iosWebviewApp, "https://github.com/appium/dotnet-client/tree/master/test/integration/apps/archives/WebViewApp.app.zip?raw=true"},
-                        {iosUICatalogApp, "https://github.com/appium/dotnet-client/tree/master/test/integration/apps/archives/UICatalog.app.zip?raw=true"},
-                        {androidApiDemos, "https://github.com/appium/dotnet-client/tree/master/test/integration/apps/archives/ApiDemos-debug.zip?raw=true"},
-                        {vodqaApp, "https://github.com/appium/dotnet-client/tree/master/test/integration/apps/archives/vodqa.zip?raw=true"}
+                        {iosTestApp, "https://github.com/appium/dotnet-client/blob/main/test/integration/apps/archives/TestApp.app.zip?raw=true"},
+                        {iosWebviewApp, "https://github.com/appium/dotnet-client/blob/main/test/integration/apps/archives/WebViewApp.app.zip?raw=true"},
+                        {iosUICatalogApp, "https://github.com/appium/dotnet-client/blob/main/test/integration/apps/archives/UICatalog.app.zip?raw=true"},
+                        {androidApiDemos, "https://github.com/appium/dotnet-client/blob/main/test/integration/apps/archives/ApiDemos-debug.zip?raw=true"},
+                        {vodqaApp, "https://github.com/appium/dotnet-client/blob/main/test/integration/apps/archives/vodqa.zip?raw=true"}
                     };
                 }
                 else


### PR DESCRIPTION
## List of changes

When trying to use tree/master in the apps path we get an error related to zip file

once switching to blob/main all seems to work fine
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github) 
