### PR TITLE
docs: Add link to NuGet version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # appium-dotnet-client
 
-![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Appium.WebDriver)
+[![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Appium.WebDriver)](https://www.nuget.org/packages/Appium.WebDriver/absoluteLatest)
 [![Build and deploy NuGet package](https://github.com/appium/dotnet-client/actions/workflows/release-nuget.yml/badge.svg)](https://github.com/appium/dotnet-client/actions/workflows/release-nuget.yml)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Appium.Webdriver.svg)](https://www.nuget.org/packages/Appium.Webdriver)
 


### PR DESCRIPTION
## List of changes

the NuGet badge was missing a proper link
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [x] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github) 
