### PR TITLE
test: Add tests for W3C Actions

### DIFF
--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -1,0 +1,189 @@
+﻿using Appium.Net.Integration.Tests.helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium;
+using System.Collections.Generic;
+using OpenQA.Selenium.Interactions;
+using System;
+using static OpenQA.Selenium.Interactions.PointerInputDevice;
+using PointerInputDevice = OpenQA.Selenium.Appium.Interactions.PointerInputDevice;
+
+namespace Appium.Net.Integration.Tests.Android
+{
+    internal class ActionsChainsTest
+    {
+        private AndroidDriver _driver;
+
+        [OneTimeSetUp]
+        public void BeforeAll()
+        {
+            var capabilities = Env.ServerIsRemote()
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get(Apps.androidApiDemos))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get(Apps.androidApiDemos));
+            var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
+            _driver = new AndroidDriver(serverUri, capabilities, Env.InitTimeoutSec);
+            _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _driver?.ActivateApp(Apps.GetId(Apps.androidApiDemos));
+        }
+
+        [TearDown]
+        public void TearDowwn()
+        {
+            _ = _driver?.TerminateApp(Apps.GetId(Apps.androidApiDemos));
+        }
+
+        [OneTimeTearDown]
+        public void AfterAll()
+        {
+            _driver?.Quit();
+            if (!Env.ServerIsRemote())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test]
+        public void SimpleTouchActionTestCase()
+        {
+            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+
+            var number1 = els.Count;
+            var elementToTouch = els[2];
+
+            var touch = new PointerInputDevice(PointerKind.Touch, "finger");
+            var sequence = new ActionSequence(touch);
+
+            PointerEventProperties pointerEventProperties = new PointerEventProperties
+            {
+                Pressure = 1
+            };
+
+            var move = touch.CreatePointerMove(elementToTouch, elementToTouch.Location.X, elementToTouch.Location.Y,TimeSpan.FromSeconds(1));
+            var actionPress = touch.CreatePointerDown(MouseButton.Touch, pointerEventProperties);
+            var pause = touch.CreatePause(TimeSpan.FromMilliseconds(250));
+            var actionRelease = touch.CreatePointerUp(MouseButton.Touch);
+
+            sequence.AddAction(move);
+            sequence.AddAction(actionPress);
+            sequence.AddAction(pause);
+            sequence.AddAction(actionRelease);
+
+            var actions_seq = new List<ActionSequence>
+            {
+                sequence
+            };
+
+            _driver.PerformActions(actions_seq);
+
+            els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+
+            Assert.AreNotEqual(number1, els.Count);
+        }
+
+        [Test]
+        public void ScrollActionTestCase()
+        {
+            AppiumElement ViewsElem = _driver.FindElement(MobileBy.AccessibilityId("Views"));
+
+            ActionBuilder actionBuilder = new ActionBuilder();
+
+            var touch = new PointerInputDevice(PointerKind.Touch, "finger");
+
+            var moveAction = touch.CreatePointerMove(ViewsElem, 0, 0, TimeSpan.FromMilliseconds(0));
+            actionBuilder.AddAction(moveAction);
+            var tapAction = touch.CreatePointerDown(MouseButton.Touch);
+            actionBuilder.AddAction(tapAction);
+            var tapActionPause= touch.CreatePause(TimeSpan.FromMilliseconds(200));
+            actionBuilder.AddAction(tapActionPause);
+            var tapActionUp = touch.CreatePointerUp(MouseButton.Touch);
+            actionBuilder.AddAction(tapActionUp);
+
+            var sequence = actionBuilder.ToActionSequenceList();
+
+            _driver.PerformActions(sequence);
+
+            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+            var origin = els[7];
+            var loc1 = origin.Location;
+            var target = els[1];
+            var loc2 = target.Location;
+
+            actionBuilder.ClearSequences();
+
+            actionBuilder.AddAction(touch.CreatePointerMove(origin, 0,0, TimeSpan.FromMilliseconds(800)));
+            actionBuilder.AddAction(touch.CreatePointerDown(MouseButton.Touch));
+            actionBuilder.AddAction(touch.CreatePause(TimeSpan.FromMilliseconds(800)));
+            actionBuilder.AddAction(touch.CreatePointerMove(target, 0, 0, TimeSpan.FromMilliseconds(800)));
+            actionBuilder.AddAction(touch.CreatePointerUp(MouseButton.Touch));
+
+            var sequenceActions = actionBuilder.ToActionSequenceList();
+
+            _driver.PerformActions(sequenceActions);
+
+            Assert.AreNotEqual(loc1.Y, origin.Location.Y);
+            Assert.AreNotEqual(loc2.Y, target.Location.Y);
+
+        }
+
+        [Test]
+        public void ScrollUsingAddActionsTestCase()
+        {
+            AppiumElement ViewsElem = _driver.FindElement(MobileBy.AccessibilityId("Views"));
+
+            ActionBuilder actionBuilder = new ActionBuilder();
+
+            var touch = new PointerInputDevice(PointerKind.Touch, "finger");
+
+            var moveAction = touch.CreatePointerMove(ViewsElem, 0, 0, TimeSpan.FromMilliseconds(0));
+            var tapAction = touch.CreatePointerDown(MouseButton.Touch);
+            var tapActionPause = touch.CreatePause(TimeSpan.FromMilliseconds(200));
+            var tapActionUp = touch.CreatePointerUp(MouseButton.Touch);
+
+            Interaction[] Tapinteractions = new Interaction[]
+            {
+                moveAction,
+                tapAction,
+                tapActionPause,
+                tapActionUp
+            };
+
+            actionBuilder.AddActions(Tapinteractions);
+
+            var sequence = actionBuilder.ToActionSequenceList();
+
+            _driver.PerformActions(sequence);
+
+            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+            var origin = els[7];
+            var loc1 = origin.Location;
+            var target = els[1];
+            var loc2 = target.Location;
+
+            actionBuilder.ClearSequences();;
+
+            Interaction[] interactions = new Interaction[]
+            {
+                touch.CreatePointerMove(origin, 0, 0, TimeSpan.FromMilliseconds(800)),
+                touch.CreatePointerDown(MouseButton.Touch),
+                touch.CreatePause(TimeSpan.FromMilliseconds(800)),
+                touch.CreatePointerMove(target, 0, 0, TimeSpan.FromMilliseconds(800)),
+                touch.CreatePointerUp(MouseButton.Touch)
+            };
+
+            actionBuilder.AddActions(interactions);
+
+            var sequenceActions = actionBuilder.ToActionSequenceList();
+
+            _driver.PerformActions(sequenceActions);
+
+            Assert.AreNotEqual(loc1.Y, origin.Location.Y);
+            Assert.AreNotEqual(loc2.Y, target.Location.Y);
+
+        }
+    }
+}

--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -82,7 +82,7 @@ namespace Appium.Net.Integration.Tests.Android
 
             els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
 
-            Assert.AreNotEqual(number1, els.Count);
+            Assert.That(els, Has.Count.Not.EqualTo(number1));
         }
 
         [Test]
@@ -125,8 +125,11 @@ namespace Appium.Net.Integration.Tests.Android
 
             _driver.PerformActions(sequenceActions);
 
-            Assert.AreNotEqual(loc1.Y, origin.Location.Y);
-            Assert.AreNotEqual(loc2.Y, target.Location.Y);
+            Assert.Multiple(() =>
+            {
+                Assert.That(origin.Location.Y, Is.Not.EqualTo(loc1.Y));
+                Assert.That(target.Location.Y, Is.Not.EqualTo(loc2.Y));
+            });
 
         }
 
@@ -155,7 +158,6 @@ namespace Appium.Net.Integration.Tests.Android
             actionBuilder.AddActions(Tapinteractions);
 
             var sequence = actionBuilder.ToActionSequenceList();
-
             _driver.PerformActions(sequence);
 
             IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
@@ -178,11 +180,13 @@ namespace Appium.Net.Integration.Tests.Android
             actionBuilder.AddActions(interactions);
 
             var sequenceActions = actionBuilder.ToActionSequenceList();
-
             _driver.PerformActions(sequenceActions);
 
-            Assert.AreNotEqual(loc1.Y, origin.Location.Y);
-            Assert.AreNotEqual(loc2.Y, target.Location.Y);
+            Assert.Multiple(() =>
+            {
+                Assert.That(origin.Location.Y, Is.Not.EqualTo(loc1.Y));
+                Assert.That(target.Location.Y, Is.Not.EqualTo(loc2.Y));
+            });
 
         }
     }


### PR DESCRIPTION
## List of changes

Added Tests for W3C Actions, afterward we can remove the entire deprecated touch classes.

related to https://github.com/appium/dotnet-client/issues/712

@laolubenson, Maybe the test class name can be improved, WDYT?
another point to consider is how we are going to handle the ambiguous issue users will probably face.

```
using static OpenQA.Selenium.Interactions.PointerInputDevice;
using PointerInputDevice = OpenQA.Selenium.Appium.Interactions.PointerInputDevice;
```
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github) 
