### PR TITLE
test: remove test using System.Drawing.Common

### DIFF
--- a/test/integration/IOS/ClipboardTest.cs
+++ b/test/integration/IOS/ClipboardTest.cs
@@ -76,16 +76,6 @@ namespace Appium.Net.Integration.Tests.IOS
         }
 
         [Test]
-        public void WhenSetClipboardImage_GetClipboardImageShouldReturnImage()
-        {
-            var imageBytes = _driver.GetScreenshot().AsByteArray;
-            var testImage = Image.FromStream(new MemoryStream(imageBytes));
-
-            _driver.SetClipboardImage(testImage);
-            Assert.That(() => _driver.GetClipboardImage().Size, Is.EqualTo(testImage.Size));
-        }
-
-        [Test]
         public void WhenClipboardHasNoImage_GetClipboardImageShouldReturnNull()
         {
             _driver.SetClipboardText(ClipboardTestString);


### PR DESCRIPTION
## List of changes

Removal of ios clipboard test which use System.Drawing.Common
System.Drawing.Common is only supported on windows platforms. 


https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only

## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github) 
