### PR TITLE
refactor: reintroduce the .NET Framework 4.8 target framework

### DIFF
--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -27,7 +27,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RootNamespace>OpenQA.Selenium</RootNamespace>
     <Company>Appium Commiters</Company>
@@ -27,7 +27,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -39,7 +39,7 @@ namespace OpenQA.Selenium.Appium.Service
         private readonly int Port;
         private readonly TimeSpan InitializationTimeout;
         private readonly IDictionary<string, string> EnvironmentForProcess;
-#if NET6_0
+#if !NET48
         private readonly HttpClient SharedHttpClient;
 #endif
         private Process Service;

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -297,7 +297,7 @@ namespace OpenQA.Selenium.Appium.Service
                 try
                 {
 #if NET48
-                    HttpWebResponse response = await GetHttpResponse(status);
+                    HttpWebResponse response = await GetHttpResponseAsync(status);
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
                         return true;

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -20,7 +20,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+#if NET6_0
 using System.Net.Http;
+#endif
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -37,7 +39,9 @@ namespace OpenQA.Selenium.Appium.Service
         private readonly int Port;
         private readonly TimeSpan InitializationTimeout;
         private readonly IDictionary<string, string> EnvironmentForProcess;
+#if NET6_0
         private readonly HttpClient SharedHttpClient;
+#endif
         private Process Service;
         private List<string> ArgsList;
 
@@ -61,9 +65,12 @@ namespace OpenQA.Selenium.Appium.Service
             Port = port;
             InitializationTimeout = initializationTimeout;
             EnvironmentForProcess = environmentForProcess;
+#if NET6_0
             SharedHttpClient = CreateHttpClientInstance;
+#endif
         }
 
+#if NET6_0
         private HttpClient CreateHttpClientInstance
         {
             get
@@ -75,7 +82,7 @@ namespace OpenQA.Selenium.Appium.Service
                 return new HttpClient(handler);
             }
         }
-
+#endif
         /// <summary>
         /// The base URL for the managed appium server.
         /// </summary>
@@ -168,8 +175,9 @@ namespace OpenQA.Selenium.Appium.Service
             finally
             {
                 Service?.Close();
-
+#if NET6_0
                 SharedHttpClient.Dispose();
+#endif
             }
         }
 
@@ -288,12 +296,20 @@ namespace OpenQA.Selenium.Appium.Service
             {
                 try
                 {
+#if NET48
+                    HttpWebResponse response = await GetHttpResponse(status);
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        return true;
+                    }
+#elif NET6_0
                     HttpResponseMessage response = await GetHttpResponseAsync(status).ConfigureAwait(false);
 
                     if (response.IsSuccessStatusCode)
                     {
                         return true;
                     }
+#endif
                 }
                 catch
                 {
@@ -302,11 +318,21 @@ namespace OpenQA.Selenium.Appium.Service
             }
             return pinged;
         }
-
-        private async Task<HttpResponseMessage> GetHttpResponseAsync(Uri status)
+#if NET48
+        private async Task<HttpWebResponse> GetHttpResponse(Uri status)
         {
-            HttpResponseMessage response = await SharedHttpClient.GetAsync(status).ConfigureAwait(false);
-            return response;
+            return await Task.Run(() =>
+            {
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(status);
+                return (HttpWebResponse)request.GetResponse();
+            });
         }
+#elif NET6_0
+        private async Task<HttpResponseMessage> GetHttpResponseAsync(Uri status)
+            {
+                HttpResponseMessage response = await SharedHttpClient.GetAsync(status).ConfigureAwait(false);
+                return response;
+            }
+#endif
     }
 }

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -327,7 +327,7 @@ namespace OpenQA.Selenium.Appium.Service
                 return (HttpWebResponse)request.GetResponse();
             });
         }
-#elif NET
+#else
         private async Task<HttpResponseMessage> GetHttpResponseAsync(Uri status)
             {
                 HttpResponseMessage response = await SharedHttpClient.GetAsync(status).ConfigureAwait(false);

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -319,7 +319,7 @@ namespace OpenQA.Selenium.Appium.Service
             return pinged;
         }
 #if NET48
-        private async Task<HttpWebResponse> GetHttpResponse(Uri status)
+        private async Task<HttpWebResponse> GetHttpResponseAsync(Uri status)
         {
             return await Task.Run(() =>
             {

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -297,7 +297,7 @@ namespace OpenQA.Selenium.Appium.Service
                 try
                 {
 #if NET48
-                    HttpWebResponse response = await GetHttpResponseAsync(status);
+                    HttpWebResponse response = await GetHttpResponseAsync(status).ConfigureAwait(false);
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
                         return true;
@@ -325,7 +325,7 @@ namespace OpenQA.Selenium.Appium.Service
             {
                 HttpWebRequest request = (HttpWebRequest)WebRequest.Create(status);
                 return (HttpWebResponse)request.GetResponse();
-            });
+            }).ConfigureAwait(false);
         }
 #else
         private async Task<HttpResponseMessage> GetHttpResponseAsync(Uri status)

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -65,12 +65,12 @@ namespace OpenQA.Selenium.Appium.Service
             Port = port;
             InitializationTimeout = initializationTimeout;
             EnvironmentForProcess = environmentForProcess;
-#if NET6_0
+#if !NET48
             SharedHttpClient = CreateHttpClientInstance;
 #endif
         }
 
-#if NET6_0
+#if !NET48
         private HttpClient CreateHttpClientInstance
         {
             get
@@ -175,7 +175,7 @@ namespace OpenQA.Selenium.Appium.Service
             finally
             {
                 Service?.Close();
-#if NET6_0
+#if !NET48
                 SharedHttpClient.Dispose();
 #endif
             }
@@ -302,7 +302,7 @@ namespace OpenQA.Selenium.Appium.Service
                     {
                         return true;
                     }
-#elif NET6_0
+#elif NET
                     HttpResponseMessage response = await GetHttpResponseAsync(status).ConfigureAwait(false);
 
                     if (response.IsSuccessStatusCode)
@@ -327,7 +327,7 @@ namespace OpenQA.Selenium.Appium.Service
                 return (HttpWebResponse)request.GetResponse();
             });
         }
-#elif NET6_0
+#elif NET
         private async Task<HttpResponseMessage> GetHttpResponseAsync(Uri status)
             {
                 HttpResponseMessage response = await SharedHttpClient.GetAsync(status).ConfigureAwait(false);

--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -20,7 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
-#if NET6_0
+#if NET
 using System.Net.Http;
 #endif
 using System.Runtime.CompilerServices;

--- a/test/integration/Android/ClipboardTest.cs
+++ b/test/integration/Android/ClipboardTest.cs
@@ -83,7 +83,9 @@ namespace Appium.Net.Integration.Tests.Android
         }
 
         [Test]
+#if NET6_0
         [SupportedOSPlatform("windows")]
+#endif
         public void WhenGetClipboardImageGetClipboardShouldReturnNotImplementedException()
         {
             Assert.That(() => _driver.GetClipboardImage(),

--- a/test/integration/Android/ClipboardTest.cs
+++ b/test/integration/Android/ClipboardTest.cs
@@ -83,7 +83,7 @@ namespace Appium.Net.Integration.Tests.Android
         }
 
         [Test]
-#if NET6_0
+#if !NET48
         [SupportedOSPlatform("windows")]
 #endif
         public void WhenGetClipboardImageGetClipboardShouldReturnNotImplementedException()

--- a/test/integration/Appium.Net.Integration.Tests.csproj
+++ b/test/integration/Appium.Net.Integration.Tests.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="apps\**" />


### PR DESCRIPTION


## List of changes

I've been contacted by numerous people saying the fact we dropped the support for .NET Framework 4.8 has blocked them from upgrading to latest RC versions
With this PR we should be able to have backward compatability with the Net48 

## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github) 
