### PR TITLE
chore: Removal of obsolete CloseApp

### DIFF
--- a/src/Appium.Net/Appium/AppiumCommand.cs
+++ b/src/Appium.Net/Appium/AppiumCommand.cs
@@ -121,12 +121,12 @@ namespace OpenQA.Selenium.Appium
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.GetPerformanceDataTypes,
                 "/session/{sessionId}/appium/performanceData/types"),
 
-            #region (Deprecated) legacy app management
+            #region (WinAppDriver) legacy app management
 
-            new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.CloseApp,
+            new AppiumCommand(HttpCommandInfo.PostCommand, WindowsDriverCommand.CloseApp,
                 "/session/{sessionId}/appium/app/close"),
 
-            #endregion (Deprecated) legacy app management
+            #endregion (WinAppDriver) legacy app management
 
             new AppiumCommand(HttpCommandInfo.PostCommand, AppiumDriverCommand.BackgroundApp,
                 "/session/{sessionId}/appium/app/background"),

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -182,9 +182,6 @@ namespace OpenQA.Selenium.Appium
         public void PushFile(string pathOnDevice, FileInfo file) =>
             AppiumCommandExecutionHelper.PushFile(this, pathOnDevice, file);
 
-        [Obsolete("The CloseApp API is deprecated and will be removed in future versions. Please use TerminateApp instead \r\n See https://github.com/appium/appium/issues/15807")]
-        public void CloseApp() => ((IExecuteMethod)this).Execute(AppiumDriverCommand.CloseApp);
-
         public void FingerPrint(int fingerprintId) =>
             AppiumCommandExecutionHelper.FingerPrint(this, fingerprintId);
 

--- a/src/Appium.Net/Appium/AppiumDriverCommand.cs
+++ b/src/Appium.Net/Appium/AppiumDriverCommand.cs
@@ -138,15 +138,6 @@ namespace OpenQA.Selenium.Appium
         /// </summary>
         public const string ToggleLocationServices = "toggleLocationServices";
 
-        #region (Deprecated) legacy app management
-
-        /// <summary>
-        /// Close App Command.
-        /// </summary>
-        public const string CloseApp = "closeApp";
-
-        #endregion (Deprecated) legacy app management
-
         /// <summary>
         ///  Background App Command.
         /// </summary>

--- a/src/Appium.Net/Appium/Interfaces/IInteractsWithApps.cs
+++ b/src/Appium.Net/Appium/Interfaces/IInteractsWithApps.cs
@@ -71,11 +71,6 @@ namespace OpenQA.Selenium.Appium.Interfaces
         bool TerminateApp(string appId, TimeSpan timeout);
 
         /// <summary>
-        /// Closes the current app.
-        /// </summary>
-        void CloseApp();
-
-        /// <summary>
         /// Gets the State of the app.
         /// </summary>
         /// <param name="appId">a string containing the id of the app.</param>

--- a/src/Appium.Net/Appium/Windows/WindowsDriver.cs
+++ b/src/Appium.Net/Appium/Windows/WindowsDriver.cs
@@ -190,9 +190,9 @@ namespace OpenQA.Selenium.Appium.Windows
 
         #region App management
 
-        public new void CloseApp()
+        public void CloseApp()
         {
-            ((IExecuteMethod)this).Execute(AppiumDriverCommand.CloseApp);
+            ((IExecuteMethod)this).Execute(WindowsDriverCommand.CloseApp);
         }
 
         #endregion App management

--- a/src/Appium.Net/Appium/Windows/WindowsDriverCommand.cs
+++ b/src/Appium.Net/Appium/Windows/WindowsDriverCommand.cs
@@ -1,0 +1,30 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+namespace OpenQA.Selenium.Appium
+{
+    public class WindowsDriverCommand
+    {
+       
+        #region legacy app management
+
+        /// <summary>
+        /// Close App Command.
+        /// </summary>
+        public const string CloseApp = "closeApp";
+
+        #endregion legacy app management
+
+    }
+}

--- a/test/integration/Android/SettingTest.cs
+++ b/test/integration/Android/SettingTest.cs
@@ -9,17 +9,18 @@ namespace Appium.Net.Integration.Tests.Android
     public class SettingTest
     {
         private AndroidDriver _driver;
+        private readonly string _appName = "androidApiDemos";
 
         [OneTimeSetUp]
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get(_appName))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get(_appName));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;
-            _driver.CloseApp();
+            _driver.TerminateApp(Apps.GetId(_appName));
         }
 
         [Test]

--- a/test/integration/Android/WaitTests.cs
+++ b/test/integration/Android/WaitTests.cs
@@ -13,14 +13,15 @@ namespace Appium.Net.Integration.Tests.Android
     {
         private AndroidDriver _driver;
         private WebDriverWait _waitDriver;
-        private TimeSpan _driverTimeOut = TimeSpan.FromSeconds(5);
+        private readonly TimeSpan _driverTimeOut = TimeSpan.FromSeconds(5);
+        private readonly string _appKey = "androidApiDemos";
 
         [OneTimeSetUp]
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get(_appKey))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get(_appKey));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver(serverUri, capabilities, Env.InitTimeoutSec);
         }
@@ -28,7 +29,7 @@ namespace Appium.Net.Integration.Tests.Android
         [SetUp]
         public void SetUp()
         {
-            _driver.StartActivity("io.appium.android.apis", ".ApiDemos");
+            _driver.StartActivity(Apps.GetId(_appKey), ".ApiDemos");
             _waitDriver = new WebDriverWait(_driver, _driverTimeOut);
             _waitDriver.IgnoreExceptionTypes(typeof(NoSuchElementException));
         }
@@ -53,7 +54,7 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void WebDriverWaitIsWaitingTestCase()
         {
-            Stopwatch stopWatch = new Stopwatch();
+            Stopwatch stopWatch = new();
             stopWatch.Start();
 
             try
@@ -76,7 +77,7 @@ namespace Appium.Net.Integration.Tests.Android
         {
             if (_driver != null)
             {
-                _driver.CloseApp();
+                _ = _driver.TerminateApp(Apps.GetId(_appKey));
                 _driver?.Quit();
             }   
             if (!Env.ServerIsRemote())

--- a/test/integration/ServerTests/StartingAppLocallyTest.cs
+++ b/test/integration/ServerTests/StartingAppLocallyTest.cs
@@ -57,7 +57,6 @@ namespace Appium.Net.Integration.Tests.ServerTests
             }
         }
 
-
         [Test]
         public void StartingAndroidAppWithCapabilitiesOnTheServerSideTest()
         {
@@ -97,7 +96,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
             try
             {
                 driver = new IOSDriver(capabilities, Env.InitTimeoutSec);
-                driver.CloseApp();
+                driver.TerminateApp(Apps.GetId("iosTestApp"));
             }
             finally
             {
@@ -120,7 +119,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
             try
             {
                 driver = new IOSDriver(builder, capabilities, Env.InitTimeoutSec);
-                driver.CloseApp();
+                driver.TerminateApp(Apps.GetId("iosTestApp"));
             }
             finally
             {

--- a/test/integration/Windows/ClickElementTest.cs
+++ b/test/integration/Windows/ClickElementTest.cs
@@ -24,15 +24,18 @@ namespace Appium.Net.Integration.Tests.Windows
     {
         private WindowsDriver _calculatorSession;
         protected static WebElement CalculatorResult;
+        private readonly string _appId = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App";
 
         [OneTimeSetUp]
         public void BeforeAll()
         {
-            var appCapabilities = new AppiumOptions();
-            appCapabilities.AutomationName = "Windows";
-            appCapabilities.App = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App";
-            appCapabilities.DeviceName = "WindowsPC";
-            appCapabilities.PlatformName = "Windows";
+            var appCapabilities = new AppiumOptions
+            {
+                AutomationName = "Windows",
+                App = _appId,
+                DeviceName = "WindowsPC",
+                PlatformName = "Windows"
+            };
 
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _calculatorSession = new WindowsDriver(serverUri, appCapabilities,
@@ -49,8 +52,8 @@ namespace Appium.Net.Integration.Tests.Windows
         public void OneTimeTearDown()
         {
             CalculatorResult = null;
-            _calculatorSession.CloseApp();
-            _calculatorSession.Dispose();
+            _calculatorSession?.CloseApp();
+            _calculatorSession?.Dispose();
             _calculatorSession = null;
         }
 

--- a/test/integration/Windows/ImagesComparisonTest.cs
+++ b/test/integration/Windows/ImagesComparisonTest.cs
@@ -11,15 +11,18 @@ namespace Appium.Net.Integration.Tests.Windows
     {
         private WindowsDriver _calculatorSession;
         protected static WebElement CalculatorResult;
+        private readonly string _appId = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App";
 
         [OneTimeSetUp]
         public void BeforeAll()
         {
-            var appCapabilities = new AppiumOptions();
-            appCapabilities.App = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App";
-            appCapabilities.DeviceName = "WindowsPC";
-            appCapabilities.PlatformName = "Windows";
-            appCapabilities.AutomationName = "Windows";
+            var appCapabilities = new AppiumOptions
+            {
+                App = _appId,
+                DeviceName = "WindowsPC",
+                PlatformName = "Windows",
+                AutomationName = "Windows"
+            };
 
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _calculatorSession = new WindowsDriver(serverUri, appCapabilities,


### PR DESCRIPTION
## List of changes

Remove `CloseApp` from AppiumDriverCommand and move it to WindowsDriverCommand since we have no other option for the time being. (TerminateApp is not implemented on the WinAppDriver side)

Replaced all usages of `CloseApp` with `TerminateApp` in the Integration Tests
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of Appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if necessary. If there are new features, you can provide code samples showing how they work and possible use cases. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github) 
