### PR TITLE
Implementing ICommandExecutor's ExecuteAsync() and using it in Execute()

### DIFF
--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -14,6 +14,7 @@
 
 using OpenQA.Selenium.Remote;
 using System;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Appium.Service
 {
@@ -55,12 +56,18 @@ namespace OpenQA.Selenium.Appium.Service
 
         public Response Execute(Command commandToExecute)
         {
+            return Task.Run(() => RealExecutor.ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
+        }
+
+        public async Task<Response> ExecuteAsync(Command commandToExecute)
+        {
             Response result = null;
 
             try
             {
                 bool newSession = HandleNewSessionCommand(commandToExecute);
-                result = RealExecutor.Execute(commandToExecute);
+                result = Task.Run(() => RealExecutor.ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
+
                 if (newSession)
                 {
                     RealExecutor = UpdateExecutor(result, RealExecutor);


### PR DESCRIPTION
I think this *should* fix it in Selenium 4.22+, but its untested so far of course. :)

## List of changes

Implemented ICommandExecutor's ExecuteAsync().
Moved Execute() code to there and call it from Execute() with Task.Run()
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

