### PR TITLE
break: ExecuteAsync() under the hood implementation after bumping to Selenium 4.23

### DIFF
--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -58,8 +58,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.Support" Version="4.21.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+    <PackageReference Include="Selenium.Support" Version="4.22.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -60,7 +60,7 @@
     </PackageReference>
     <PackageReference Include="Selenium.Support" Version="4.23.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -58,8 +58,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.Support" Version="4.21.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+    <PackageReference Include="Selenium.Support" Version="4.23.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -60,7 +60,7 @@
     </PackageReference>
     <PackageReference Include="Selenium.Support" Version="4.23.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -58,8 +58,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.Support" Version="4.22.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
+    <PackageReference Include="Selenium.Support" Version="4.21.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -1,4 +1,4 @@
-//Licensed under the Apache License, Version 2.0 (the "License");
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
 //See the NOTICE file distributed with this work for additional
 //information regarding copyright ownership.
@@ -23,7 +23,6 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using OpenQA.Selenium.Appium.ImageComparison;
 
 namespace OpenQA.Selenium.Appium
@@ -111,14 +110,12 @@ namespace OpenQA.Selenium.Appium
 
         #region Public Methods
 
-        protected override async Task<Response> ExecuteAsync(string driverCommandToExecute, Dictionary<string, object> parameters) =>
-            await base.ExecuteAsync(driverCommandToExecute, parameters);
-
-        protected Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters) =>
-            Task.Run(() => ExecuteAsync(driverCommandToExecute, parameters)).GetAwaiter().GetResult();
+        protected override Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters) =>
+            base.Execute(driverCommandToExecute, parameters);
 
         Response IExecuteMethod.Execute(string commandName, Dictionary<string, object> parameters) =>
-            Execute(commandName, parameters);
+            base.Execute(commandName, parameters);
+
 
         #region Generic FindMethods
 

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -1,4 +1,4 @@
-﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
 //See the NOTICE file distributed with this work for additional
 //information regarding copyright ownership.
@@ -23,6 +23,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using OpenQA.Selenium.Appium.ImageComparison;
 
 namespace OpenQA.Selenium.Appium
@@ -110,12 +111,14 @@ namespace OpenQA.Selenium.Appium
 
         #region Public Methods
 
-        protected override Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters) =>
-            base.Execute(driverCommandToExecute, parameters);
+        protected override async Task<Response> ExecuteAsync(string driverCommandToExecute, Dictionary<string, object> parameters) =>
+            await base.ExecuteAsync(driverCommandToExecute, parameters);
+
+        protected Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters) =>
+            Task.Run(() => ExecuteAsync(driverCommandToExecute, parameters)).GetAwaiter().GetResult();
 
         Response IExecuteMethod.Execute(string commandName, Dictionary<string, object> parameters) =>
-            base.Execute(commandName, parameters);
-
+            Execute(commandName, parameters);
 
         #region Generic FindMethods
 

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -54,7 +54,7 @@ namespace OpenQA.Selenium.Appium.Service
             ClientConfig = clientConfig;
         }
 
-        public Response Execute(Command commandToExecute) => this.ExecuteAsync(commandToExecute).GetAwaiter().GetResult();
+        public Response Execute(Command commandToExecute) => Task.Run(() => ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
 
         public async Task<Response> ExecuteAsync(Command commandToExecute)
         {
@@ -63,7 +63,7 @@ namespace OpenQA.Selenium.Appium.Service
             try
             {
                 bool newSession = HandleNewSessionCommand(commandToExecute);
-                result = await RealExecutor.ExecuteAsync(commandToExecute);
+                result = await RealExecutor.ExecuteAsync(commandToExecute).ConfigureAwait(false);
                 if (newSession)
                 {
                     RealExecutor = UpdateExecutor(result, RealExecutor);

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -54,14 +54,16 @@ namespace OpenQA.Selenium.Appium.Service
             ClientConfig = clientConfig;
         }
 
-        public Response Execute(Command commandToExecute)
+        public Response Execute(Command commandToExecute) => this.ExecuteAsync(commandToExecute).GetAwaiter().GetResult();
+
+        public async Task<Response> ExecuteAsync(Command commandToExecute)
         {
             Response result = null;
 
             try
             {
                 bool newSession = HandleNewSessionCommand(commandToExecute);
-                result = RealExecutor.Execute(commandToExecute);
+                result = await RealExecutor.ExecuteAsync(commandToExecute);
                 if (newSession)
                 {
                     RealExecutor = UpdateExecutor(result, RealExecutor);
@@ -79,8 +81,6 @@ namespace OpenQA.Selenium.Appium.Service
                 HandleCommandCompletion(commandToExecute, result);
             }
         }
-
-        public Task<Response> ExecuteAsync(Command commandToExecute) => Task.Run(() => this.Execute(commandToExecute));
 
         /// <summary>
         /// Handles a new session command, starts the service, and modifies the HTTP request header if necessary.

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -14,6 +14,7 @@
 
 using OpenQA.Selenium.Remote;
 using System;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Appium.Service
 {

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -79,6 +79,8 @@ namespace OpenQA.Selenium.Appium.Service
             }
         }
 
+        public Task<Response> ExecuteAsync(Command commandToExecute) => Task.Run(() => this.Execute(commandToExecute));
+
         /// <summary>
         /// Handles a new session command, starts the service, and modifies the HTTP request header if necessary.
         /// </summary>

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -54,7 +54,10 @@ namespace OpenQA.Selenium.Appium.Service
             ClientConfig = clientConfig;
         }
 
-        public Response Execute(Command commandToExecute) => Task.Run(() => ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
+        public Response Execute(Command commandToExecute)
+       {
+           return Task.Run(() => ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
+       }
 
         public async Task<Response> ExecuteAsync(Command commandToExecute)
         {

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -1,4 +1,4 @@
-﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
 //See the NOTICE file distributed with this work for additional
 //information regarding copyright ownership.
@@ -14,6 +14,7 @@
 
 using OpenQA.Selenium.Remote;
 using System;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Appium.Service
 {
@@ -55,12 +56,18 @@ namespace OpenQA.Selenium.Appium.Service
 
         public Response Execute(Command commandToExecute)
         {
+            return Task.Run(() => RealExecutor.ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
+        }
+
+        public async Task<Response> ExecuteAsync(Command commandToExecute)
+        {
             Response result = null;
 
             try
             {
                 bool newSession = HandleNewSessionCommand(commandToExecute);
-                result = RealExecutor.Execute(commandToExecute);
+                result = Task.Run(() => RealExecutor.ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
+
                 if (newSession)
                 {
                     RealExecutor = UpdateExecutor(result, RealExecutor);
@@ -125,7 +132,7 @@ namespace OpenQA.Selenium.Appium.Service
             if (command.Name == DriverCommand.NewSession)
             {
                 Service?.Dispose();
-            }  
+            }
         }
 
         /// <summary>

--- a/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
+++ b/src/Appium.Net/Appium/Service/AppiumCommandExecutor.cs
@@ -1,4 +1,4 @@
-//Licensed under the Apache License, Version 2.0 (the "License");
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
 //See the NOTICE file distributed with this work for additional
 //information regarding copyright ownership.
@@ -14,7 +14,6 @@
 
 using OpenQA.Selenium.Remote;
 using System;
-using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Appium.Service
 {
@@ -56,18 +55,12 @@ namespace OpenQA.Selenium.Appium.Service
 
         public Response Execute(Command commandToExecute)
         {
-            return Task.Run(() => RealExecutor.ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
-        }
-
-        public async Task<Response> ExecuteAsync(Command commandToExecute)
-        {
             Response result = null;
 
             try
             {
                 bool newSession = HandleNewSessionCommand(commandToExecute);
-                result = Task.Run(() => RealExecutor.ExecuteAsync(commandToExecute)).GetAwaiter().GetResult();
-
+                result = RealExecutor.Execute(commandToExecute);
                 if (newSession)
                 {
                     RealExecutor = UpdateExecutor(result, RealExecutor);
@@ -132,7 +125,7 @@ namespace OpenQA.Selenium.Appium.Service
             if (command.Name == DriverCommand.NewSession)
             {
                 Service?.Dispose();
-            }
+            }  
         }
 
         /// <summary>


### PR DESCRIPTION
## List of changes

This bumps to Selenium 4.23 and fixes the build errors in AppiumDriver and AppiumCommandExecutor to flow through the new ExecuteAsync() methods in Selenium 4.23+.  Fixes #798 
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
