### PR TITLE
feat: Override selenium default command timeout

### DIFF
--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -38,7 +38,7 @@ namespace OpenQA.Selenium.Appium
         /// <summary>
         /// The default command timeout for HTTP requests in a AppiumDriver instance.
         /// </summary>
-        private static new readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(600.0);
+        protected static new readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(600.0);
 
         #region Constructors
 

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -35,6 +35,11 @@ namespace OpenQA.Selenium.Appium
     {
         private const string NativeApp = "NATIVE_APP";
 
+        /// <summary>
+        /// The default command timeout for HTTP requests in a AppiumDriver instance.
+        /// </summary>
+        private static new readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(600.0);
+
         #region Constructors
 
         public AppiumDriver(ICommandExecutor commandExecutor, ICapabilities appiumOptions)


### PR DESCRIPTION
## List of changes

Override and increase the default HTTP requests command timeout from 1 minute to 10 minutes.
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix or New feature)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
