### PR TITLE
github: Add Documentation category in release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,7 @@ categories:
     label: 'Chore'  
   - title: '📚 Documentation'
     labels:
-      - 'Docs'
+      - 'Documentation'
 
 version-resolver:
   major:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,6 +22,9 @@ categories:
       - 'Build'
   - title: '🧰 Maintenance'
     label: 'Chore'  
+  - title: '📚 Documentation'
+    labels:
+      - 'Docs'
 
 version-resolver:
   major:


### PR DESCRIPTION
Add new category titled "📚 Documentation" for PRs labeled with Docs in release.drafter

## List of changes

Please provide a briefly described change list that you are going to propose. 
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix or New feature)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
