### PR TITLE
docs: Remove the Deprecated Methods section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ For example, some changes in the Selenium binding could break the Appium client.
 > Regardless, moving to appium 2.x is highly recommended since appium 1.x is no longer maintained. <br/>
 > For more details about how to migrate to 2.x, see the following link : [appium 2.x migrating](https://appium.github.io/appium/docs/en/2.0/guides/migrating-1-to-2/)
 
-### Deprecated Methods
-
-> [!CAUTION]
-> - `MultiAction` and `TouchAction` are deprecated. Please use W3C WebDriver actions or mobile: extensions.
-> - `LaunchApp`, `CloseApp`, and `reset` are deprecated, please read each deprecation message as an alternative method.
-> - The `ReplaceValue` method is deprecated and will be removed in future versions. Please use the following command extensions: 'mobile: replaceElementValue' instead.
-> - The `SetImmediateValue` method is deprecated and will be removed in future versions. Please use 'SendKeys' instead.
-
 #### Additional Information
 W3C Actions: https://www.selenium.dev/documentation/webdriver/actions_api  <br/>
 App management: Please read [issue #15807](https://github.com/appium/appium/issues/15807) for more details


### PR DESCRIPTION
## List of changes

All deprecated methods are already long gone, and an active PR is also in place for TouchActions.
now it's a good time to remove that section.
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Documentation
- [x] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix or New feature)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
