### PR TITLE
refactor: Use `netstandard2.0` as target framework to support wider frameworks

### DIFF
--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>OpenQA.Selenium</RootNamespace>
+    <LangVersion>latest</LangVersion>
     <Company>Appium Commiters</Company>
     <Product>Dotnet-Client</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright © 2023</Copyright>
-    <PackageProjectUrl>https://github.com/appium/dotnet-client</PackageProjectUrl>
+    <PackageProjectUrl>https://appium.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/appium/dotnet-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
@@ -19,40 +19,25 @@
     <PackageIcon>appium-icon.png</PackageIcon>
     <Description>Selenium Webdriver extension for Appium.</Description>
     <PackageTags>Appium Webdriver device automation</PackageTags>
-  </PropertyGroup>
-  <PropertyGroup>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-  </PropertyGroup>
-  <PropertyGroup>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net48|AnyCPU'">
-    <NoWarn>1701;1702;1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net48|AnyCPU'">
-    <NoWarn>1701;1702;1591</NoWarn>
-  </PropertyGroup>
+  
   <ItemGroup>
     <None Include="LICENSE.txt" Pack="true" PackagePath="" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="appium-icon.png" Pack="true" PackagePath="" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
-  <ItemGroup>
-	<None Include="..\..\README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -61,9 +46,5 @@
     <PackageReference Include="Selenium.Support" Version="4.24.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-    <Folder Include="Appium\Mac\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## List of changes

Currently Appium targets to support:
- net6.0
- net framework 4.8
 
It means that I cannot use Appium with .net framework 4.7

## Types of changes

Use `netstandard2.0` to cover more frameworks.

https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#when-to-target-net80-vs-netstandard

> For existing code that targets .NET Standard 2.0 or later, there's no need to change the TFM to net8.0 or a later TFM. The only reason to retarget from .NET Standard to .NET 8+ would be to gain access to more runtime features, language features, or APIs.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
