### PR TITLE
fix: Revert changes for NEW_CONTRIBUTORS

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,22 +5,22 @@ template: |
 
   $CHANGES
 
-  ## 🚀 New Contributors
-  Thanks to the following contributors for their first PR:
-  $NEW_CONTRIBUTORS
+  ## 🚀  Contributors
+  Thanks to the following contributors in this release: 
+  $CONTRIBUTORS
   
 categories:
-  - title: 'Enhancements'
+  - title: '✨ Enhancements'
     label: 'Enhancement'
-  - title: 'Bug Fixes'
+  - title: '🐛 Bug Fixes'
     labels:
       - 'BugFix'
-  - title: 'Refactor'
+  - title: '🔄 Refactor'
     label: 'Refactor'
   - title: '📦 Dependencies'
     labels:
       - 'Dependencies'
-  - title: 'Pipeline'
+  - title: '🛠️ Pipeline'
     labels:
       - 'CI'
       - 'Build'
@@ -41,8 +41,9 @@ version-resolver:
     labels:
       - 'BugFix'
       - 'Dependencies'
+      - 'Hotfixes'
   default: patch
   
 prerelease: false
 prerelease-identifier: 'rc'
-contribution-template: '- $NAME contributed in $PULL_REQUEST'
+contribution-template: '- $NAME contributed via $PULL_REQUEST'


### PR DESCRIPTION
## List of changes

- Apparently, NEW_CONTRIBUTORS is not supported(yet), so rolled back those changes.
- Added missing emojis per category
- better readability for contributors' template


## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
