### PR TITLE
github: Remove the selenium group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,13 @@ updates:
     # Files stored in src/Appium.Net directory
     directory: "/src/Appium.Net" 
     schedule:
-      interval: "daily"
-    groups:
-      selenium-dependencies:
-        patterns:
-          - "Selenium.*" 
+      interval: "weekly"
 
   - package-ecosystem: "nuget"
     # Files stored in test/integration directory
     directory: "/test/integration" 
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -22,7 +18,7 @@ updates:
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       # Prefix all commit messages with "[github-actions] "
       prefix: "[github-actions] "


### PR DESCRIPTION
## List of changes

Remove the selenium group (since there is only one package) and update the test/integration schedule to a weekly
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
