### PR TITLE
BREAKING CHANGE: `AndroidDriver` to use modern `mobile:` commands for Lock, IsLocked and Unlock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "nuget"
     # Files stored in src/Appium.Net directory
-    directory: "src/Appium.Net" 
+    directory: "/src/Appium.Net" 
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "nuget"
     # Files stored in test/integration directory
-    directory: "test/integration" 
+    directory: "/test/integration" 
     schedule:
       interval: "weekly"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "nuget"
     # Files stored in src/Appium.Net directory
-    directory: "/src/Appium.Net" 
+    directory: "src/Appium.Net" 
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "nuget"
     # Files stored in test/integration directory
-    directory: "/test/integration" 
+    directory: "test/integration" 
     schedule:
       interval: "weekly"
 

--- a/src/Appium.Net/Appium/Android/AndroidCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/Android/AndroidCommandExecutionHelper.cs
@@ -170,12 +170,6 @@ namespace OpenQA.Selenium.Appium.Android
 
         #endregion
 
-        public static bool IsLocked(IExecuteMethod executeMethod) =>
-            (bool) executeMethod.Execute(AppiumDriverCommand.IsLocked).Value;
-
-        public static void Unlock(IExecuteMethod executeMethod) =>
-            executeMethod.Execute(AppiumDriverCommand.UnlockDevice);
-
         public static Dictionary<string, object> GetSettings(IExecuteMethod executeMethod) =>
             (Dictionary<string, object>) executeMethod.Execute(AppiumDriverCommand.GetSettings).Value;
 

--- a/src/Appium.Net/Appium/Android/AndroidDriver.cs
+++ b/src/Appium.Net/Appium/Android/AndroidDriver.cs
@@ -287,21 +287,67 @@ namespace OpenQA.Selenium.Appium.Android
 
         #region Device Interactions
 
-        /**
-        * This method locks a device.
-        */
-        public void Lock() => AppiumCommandExecutionHelper.Lock(this, 0);
+        /// <summary>
+        /// Locks the device. Optionally, unlocks it after a specified number of seconds.
+        /// </summary>
+        /// <param name="seconds">
+        /// The number of seconds after which the device will be automatically unlocked. 
+        /// Set to 0 or leave it empty to require manual unlock.
+        /// </param>
+        /// <exception cref="WebDriverException">Thrown if the command execution fails.</exception>
+        public void Lock(int? seconds = null)
+        {
+            var parameters = new Dictionary<string, object>();
+
+            if (seconds.HasValue && seconds.Value > 0)
+            {
+                parameters["seconds"] = seconds.Value;
+            }
+
+            ExecuteScript("mobile: lock", parameters);
+        }
 
         /// <summary>
         /// Check if the device is locked
         /// </summary>
         /// <returns>true if device is locked, false otherwise</returns>
-        public bool IsLocked() => AndroidCommandExecutionHelper.IsLocked(this);
+        public bool IsLocked() => (bool)ExecuteScript("mobile: isLocked");
 
-        /**
-         * This method unlocks a device.
-         */
-        public void Unlock() => AndroidCommandExecutionHelper.Unlock(this);
+        /// <summary>
+        /// Unlocks the device if it is locked. No operation if the device's screen is not locked.
+        /// </summary>
+        /// <param name="key">The unlock key. See the documentation on appium:unlockKey capability for more details.</param>
+        /// <param name="type">The unlock type. See the documentation on appium:unlockType capability for more details.</param>
+        /// <param name="strategy">Optional unlock strategy. See the documentation on appium:unlockStrategy capability for more details.</param>
+        /// <param name="timeoutMs">Optional unlock timeout in milliseconds. See the documentation on appium:unlockSuccessTimeout capability for more details.</param>
+        /// <exception cref="ArgumentException">Thrown when required arguments are null or empty.</exception>
+        /// <exception cref="WebDriverException">Thrown if the command execution fails.</exception>
+        public void Unlock(string key, string type, string? strategy = null, int? timeoutMs = null)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Unlock key is required and cannot be null or whitespace.", nameof(key));
+
+            if (string.IsNullOrWhiteSpace(type))
+                throw new ArgumentException("Unlock type is required and cannot be null or whitespace.", nameof(type));
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "key", key },
+                { "type", type }
+            };
+
+            if (strategy != null && !string.IsNullOrWhiteSpace(strategy))
+            {
+                parameters["strategy"] = strategy;
+            }
+
+            if (timeoutMs.HasValue)
+            {
+                parameters["timeoutMs"] = timeoutMs.Value;
+            }
+
+            ExecuteScript("mobile: unlock", parameters);
+        }
 
         #endregion
 

--- a/test/integration/Android/LockDeviceTest.cs
+++ b/test/integration/Android/LockDeviceTest.cs
@@ -34,7 +34,7 @@ namespace Appium.Net.Integration.Tests.Android
         {
             _driver.Lock();
             Assert.That(_driver.IsLocked(), Is.EqualTo(true));
-            _driver.Unlock();
+            _driver.Unlock("12345","password");
             Assert.That(_driver.IsLocked(), Is.EqualTo(false));
         }
     }


### PR DESCRIPTION
## List of changes

- Replaced deprecated JSONWP commands with `mobile: lock`, `mobile: isLocked`, and `mobile: unlock` extensions.
- Updated the `Lock` method to accept an optional `seconds` parameter for auto-unlock functionality.
- Updated the `Unlock` method to support required `key` and `type` parameters, with optional `strategy` and `timeoutMs` arguments.
- Improved code robustness with null checks and parameter validation.
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
