### PR TITLE
test: fix assertion for logs entry

### DIFF
--- a/test/integration/Android/Session/LogTests.cs
+++ b/test/integration/Android/Session/LogTests.cs
@@ -87,7 +87,7 @@ namespace Appium.Net.Integration.Tests.Android.Session.Logs
             Assert.That(availableLogTypes, Has.Member(BugReportLogType));
 
             var bugReportLogEntry = _driver.Manage().Logs.GetLog(BugReportLogType);
-            Assert.That(bugReportLogEntry, Is.Not.Null.And.Count.EqualTo(1));
+            Assert.That(bugReportLogEntry, Is.Not.Null.And.Count.AtLeast(1));
             var bugReportLogPath = bugReportLogEntry.FirstOrDefault()?.Message;
 
             var match = Regex.Match(bugReportLogPath ?? throw new InvalidOperationException(), @"^([\s\S])*.zip");


### PR DESCRIPTION
## List of changes

When getting bugreport logs, there is more than one entry.
can`t recall how it used to be.
@laolubenson / @KazuCocoa Maybe you guys recall if it's normal behavier:
![image](https://github.com/user-attachments/assets/45125fdb-05f7-4b64-abef-aff4bec3a6a7)
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
