### PR TITLE
test: Replace deprecated `ByIosUIAutomation` in ScrollingSearchingTest

### DIFF
--- a/test/integration/IOS/ScrollingSearchingTest.cs
+++ b/test/integration/IOS/ScrollingSearchingTest.cs
@@ -1,4 +1,5 @@
-﻿using Appium.Net.Integration.Tests.helpers;
+﻿using System.Collections.Generic;
+using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.iOS;
@@ -29,21 +30,20 @@ namespace Appium.Net.Integration.Tests.IOS
         }
 
         [Test]
-        public void ScrollToTestCase()
+        public void ScrollToToolbarsElementUsingToVisibleTrueTest()
         {
-            var slider = _driver
-                .FindElement(new ByIosUIAutomation(".tableViews()[0]"
-                                                   + ".scrollToElementWithPredicate(\"name CONTAINS 'Slider'\")"));
-            Assert.That(slider.GetAttribute("name"), Is.EqualTo("Sliders"));
+            var Toolbars = _driver.FindElement(new ByIosNSPredicate("name == 'Toolbars'"));
+            _driver.ExecuteScript("mobile: scroll", new Dictionary<string, string> { { "element", Toolbars.Id }, { "toVisible", "true" } });
+            Assert.That(Toolbars.Displayed, Is.True, "The 'Toolbars' element should be visible after scrolling.");
         }
 
         [Test]
-        public void ScrollToExactTestCase()
+        public void ScrollToSwitchesElementUsingDirectionDownTest()
         {
-            var table = _driver.FindElement(new ByIosUIAutomation(".tableViews()[0]"));
-            var slider = table.FindElement(
-                new ByIosUIAutomation(".scrollToElementWithPredicate(\"name CONTAINS 'Slider'\")"));
-            Assert.That(slider.GetAttribute("name"), Is.EqualTo("Sliders"));
+            var table = _driver.FindElement(new ByIosNSPredicate("type == 'XCUIElementTypeTable'"));
+            _driver.ExecuteScript("mobile: scroll", new Dictionary<string, string> { { "direction", "down" }, { "element", table.Id } });
+            var switches = table.FindElement(new ByIosNSPredicate("name CONTAINS 'Switches'"));
+            Assert.That(switches.GetAttribute("visible"), Is.EqualTo("true"));
         }
     }
 }


### PR DESCRIPTION
## List of changes

update scrolling tests to use modern mobile commands for visibility checks
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
