### PR TITLE
test: Disable `FullReset` in IOS/ClipboardTest

### DIFF
--- a/test/integration/IOS/ClipboardTest.cs
+++ b/test/integration/IOS/ClipboardTest.cs
@@ -15,11 +15,11 @@ namespace Appium.Net.Integration.Tests.IOS
         private const string ClipboardTestString = "Hello Clipboard";
         private const string Base64RegexPattern = @"^[a-zA-Z0-9\+/]*={0,2}$";
 
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             var capabilities = Caps.GetIosCaps(Apps.Get("iosUICatalogApp"));
-            capabilities.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
+            capabilities.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
 
             _driver = new IOSDriver(serverUri, capabilities, Env.InitTimeoutSec);
@@ -94,7 +94,7 @@ namespace Appium.Net.Integration.Tests.IOS
             Assert.That(() => _driver.GetClipboardText(), Is.Empty);
         }
 
-        [TearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             if (_driver.IsLocked())


### PR DESCRIPTION
## List of changes

update ClipboardTest to use OneTimeSetUp and OneTimeTearDown, disable full reset
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
