### PR TITLE
fix: Init method in Env.cs for better initialization

### DIFF
--- a/test/integration/helpers/Env.cs
+++ b/test/integration/helpers/Env.cs
@@ -26,9 +26,13 @@ namespace Appium.Net.Integration.Tests.helpers
 
             try
             {
-                var path = AppDomain.CurrentDomain.BaseDirectory;
-                var sr = new StreamReader(path + "env.json");
-                var jsonString = sr.ReadToEnd();
+                string path = AppDomain.CurrentDomain.BaseDirectory;
+                if (!path.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                {
+                    path += Path.DirectorySeparatorChar;
+                }
+                StreamReader sr = new(path + "env.json");
+                string jsonString = sr.ReadToEnd();
                 _env = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonString, new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true

--- a/test/integration/helpers/Env.cs
+++ b/test/integration/helpers/Env.cs
@@ -15,14 +15,14 @@ namespace Appium.Net.Integration.Tests.helpers
 
         private static void Init()
         {
+            if (_initialized) return;
+
             _env = new Dictionary<string, JsonElement>
             {
                 { "DEV", JsonDocument.Parse("true").RootElement }, 
                 { "isRemoteAppiumServer", JsonDocument.Parse("false").RootElement }, 
                 { "remoteAppiumServerUri", JsonDocument.Parse("\"http://localhost:4723\"").RootElement }
             };
-
-            if (_initialized) return;
 
             try
             {

--- a/test/integration/helpers/Env.cs
+++ b/test/integration/helpers/Env.cs
@@ -27,11 +27,9 @@ namespace Appium.Net.Integration.Tests.helpers
             try
             {
                 string path = AppDomain.CurrentDomain.BaseDirectory;
-                if (!path.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                {
-                    path += Path.DirectorySeparatorChar;
-                }
-                StreamReader sr = new(path + "env.json");
+                var filepath = Path.Combine(path, "env.json");
+
+                StreamReader sr = new(filepath);
                 string jsonString = sr.ReadToEnd();
                 _env = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonString, new JsonSerializerOptions
                 {

--- a/test/integration/helpers/Env.cs
+++ b/test/integration/helpers/Env.cs
@@ -26,7 +26,6 @@ namespace Appium.Net.Integration.Tests.helpers
 
             try
             {
-                _initialized = true;
                 var path = AppDomain.CurrentDomain.BaseDirectory;
                 var sr = new StreamReader(path + "env.json");
                 var jsonString = sr.ReadToEnd();
@@ -34,6 +33,7 @@ namespace Appium.Net.Integration.Tests.helpers
                 {
                     PropertyNameCaseInsensitive = true
                 });
+                _initialized = true;
             }
             catch (JsonException jsonEx)
             {


### PR DESCRIPTION
## List of changes

Reordered the Init method to check _initialized flag at the start, ensuring early return if already initialized. Moved _env dictionary initialization before the check to guarantee setup before any operations. Removed _initialized flag setting and env.json reading from the try block, simplifying the initialization logic.
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
