### PR TITLE
test: Refactor DirectConnectTest for readability and consistency

### DIFF
--- a/test/integration/ServerTests/DirectConnectTest.cs
+++ b/test/integration/ServerTests/DirectConnectTest.cs
@@ -26,13 +26,10 @@ namespace Appium.Net.Integration.Tests.ServerTests
         [Test]
         public void WithAnEmptyBody()
         {
+            var emptyBody = new Dictionary<string, object>();
+            var response = new Response(null, emptyBody, WebDriverResult.Success);
 
-            Response response = new Response();
-            Dictionary<string, object> emptyBody = new Dictionary<string, object>();
-
-            response.Value = emptyBody;
-
-            DirectConnect directConnect = new DirectConnect(response);
+            DirectConnect directConnect = new(response);
             Assert.That(directConnect.GetUri(), Is.Null);
         }
 
@@ -40,52 +37,68 @@ namespace Appium.Net.Integration.Tests.ServerTests
         [Test]
         public void WithAppiumPrefixResponsesWithAppium()
         {
+            var body = new Dictionary<string, object>
+            {
+                ["appium:directConnectProtocol"] = "https",
+                ["appium:directConnectHost"] = "example.com",
+                ["appium:directConnectPort"] = "9090",
+                ["appium:directConnectPath"] = "/path/to/new/direction"
+            };
 
-            Response response = new Response();
-            Dictionary<string, object> body = new Dictionary<string, object>();
-            body["appium:directConnectProtocol"] = "https";
-            body["appium:directConnectHost"] = "example.com";
-            body["appium:directConnectPort"] = "9090";
-            body["appium:directConnectPath"] = "/path/to/new/direction";
+            var response = new Response(null, body, WebDriverResult.Success);
 
-            response.Value = body;
-
-            DirectConnect directConnect = new DirectConnect(response);
+            var directConnect = new DirectConnect(response);
             Assert.That(directConnect.GetUri().ToString(), Is.EqualTo("https://example.com:9090/path/to/new/direction"));
         }
 
         [Test]
         public void WithAppiumPrefixResponsesWithoutAppium()
         {
+            var body = new Dictionary<string, object>
+            {
+                ["directConnectProtocol"] = "https",
+                ["directConnectHost"] = "example.com",
+                ["directConnectPort"] = "9090",
+                ["directConnectPath"] = "/path/to/new/direction"
+            };
 
-            Response response = new Response();
-            Dictionary<string, object> body = new Dictionary<string, object>();
-            body["directConnectProtocol"] = "https";
-            body["directConnectHost"] = "example.com";
-            body["directConnectPort"] = "9090";
-            body["directConnectPath"] = "/path/to/new/direction";
+            var response = new Response(null, body, WebDriverResult.Success);
 
-            response.Value = body;
-
-            DirectConnect directConnect = new DirectConnect(response);
+            var directConnect = new DirectConnect(response);
             Assert.That(directConnect.GetUri().ToString(), Is.EqualTo("https://example.com:9090/path/to/new/direction"));
         }
 
         [Test]
         public void WithAppiumPrefixResponsesInvalidProtocol()
         {
+            var body = new Dictionary<string, object>
+            {
+                ["directConnectProtocol"] = "http",
+                ["directConnectHost"] = "example.com",
+                ["directConnectPort"] = "9090",
+                ["directConnectPath"] = "/path/to/new/direction"
+            };
 
-            Response response = new Response();
-            Dictionary<string, object> body = new Dictionary<string, object>();
-            body["directConnectProtocol"] = "http";
-            body["directConnectHost"] = "example.com";
-            body["directConnectPort"] = "9090";
-            body["directConnectPath"] = "/path/to/new/direction";
+            var response = new Response(null, body, WebDriverResult.InvalidArgument);
 
-            response.Value = body;
-
-            DirectConnect directConnect = new DirectConnect(response);
+            var directConnect = new DirectConnect(response);
             Assert.That(directConnect.GetUri(), Is.Null);
         }
+        [Test]
+        public void WithMissingDirectConnectHost()
+        {
+            var body = new Dictionary<string, object>
+            {
+                ["appium:directConnectProtocol"] = "https",
+                ["appium:directConnectPort"] = "9090",
+                ["appium:directConnectPath"] = "/path/to/new/direction"
+            };
+
+            var response = new Response(null, body, WebDriverResult.Success);
+
+            var directConnect = new DirectConnect(response);
+            Assert.That(directConnect.GetUri(), Is.Null);
+        }
+
     }
 }


### PR DESCRIPTION
OpenQA.Selenium.Response class will be deprecated in selenium 4.30
I've updated the code under `test/integration/ServerTests/DirectConnectTest.cs ` to follow the New Response ctor.

Refactored `DirectConnectTest` class to improve code readability and consistency. Updated test methods to use modern C# features such as inline variable declarations, collection initializers, and object initializers. Added a new test method `WithMissingDirectConnectHost` to cover the missing `directConnectHost` scenario.

## List of changes

Please provide a briefly described change list that you are going to propose. 
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
