### PR TITLE
fix: use ToLowerInvariant in clipboard to follow invariant culture

### DIFF
--- a/src/Appium.Net/Appium/AppiumCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/AppiumCommandExecutionHelper.cs
@@ -85,10 +85,7 @@ namespace OpenQA.Selenium.Appium
         public static void SetClipboard(IExecuteMethod executeMethod, ClipboardContentType clipboardContentType,
             string base64Content)
         {
-            // driver converts this content type to lower/upper properly on their side,
-            // but some environment might not work expected. Here sends upper case
-            // to cover https://github.com/appium/dotnet-client/issues/916
-            var contentType = clipboardContentType.ToString().ToUpper();
+            var contentType = clipboardContentType.ToString().ToLowerInvariant();
 
             switch (clipboardContentType)
             {
@@ -114,10 +111,7 @@ namespace OpenQA.Selenium.Appium
 
         public static string GetClipboard(IExecuteMethod executeMethod, ClipboardContentType clipboardContentType)
         {
-            // driver converts this content type to lower/upper properly on their side,
-            // but some environment might not work expected. Here sends upper case
-            // to cover https://github.com/appium/dotnet-client/issues/916
-            var contentType = clipboardContentType.ToString().ToUpper();
+            var contentType = clipboardContentType.ToString().ToLowerInvariant();
             switch (clipboardContentType)
             {
                 case ClipboardContentType.Image:
@@ -150,10 +144,7 @@ namespace OpenQA.Selenium.Appium
                     new object[]
                     {
                         Convert.ToBase64String(encodedStringContentBytes),
-                        // driver converts this content type to lower/upper properly on their side,
-                        // but some environment might not work expected. Here sends upper case
-                        // to cover https://github.com/appium/dotnet-client/issues/916
-                        ClipboardContentType.PlainText.ToString().ToUpper(), label
+                        ClipboardContentType.PlainText.ToString().ToLowerInvariant(), label
                     })).Value;
         }
 

--- a/src/Appium.Net/Appium/AppiumCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/AppiumCommandExecutionHelper.cs
@@ -85,6 +85,11 @@ namespace OpenQA.Selenium.Appium
         public static void SetClipboard(IExecuteMethod executeMethod, ClipboardContentType clipboardContentType,
             string base64Content)
         {
+            // driver converts this content type to lower/upper properly on their side,
+            // but some environment might not work expected. Here sends upper case
+            // to cover https://github.com/appium/dotnet-client/issues/916
+            var contentType = clipboardContentType.ToString().ToUpper();
+
             switch (clipboardContentType)
             {
                 case ClipboardContentType.Image:
@@ -97,18 +102,22 @@ namespace OpenQA.Selenium.Appium
 
                     executeMethod.Execute(AppiumDriverCommand.SetClipboard,
                         PrepareArguments(new[] {"content", "contentType", "label"},
-                            new object[] {base64Content, clipboardContentType.ToString().ToLower(), null}));
+                            new object[] {base64Content, contentType, null}));
                     break;
                 default:
                     executeMethod.Execute(AppiumDriverCommand.SetClipboard,
                         PrepareArguments(new[] {"content", "contentType", "label"},
-                            new object[] {base64Content, clipboardContentType.ToString().ToLower(), null}));
+                            new object[] {base64Content, contentType, null}));
                     break;
             }
         }
 
         public static string GetClipboard(IExecuteMethod executeMethod, ClipboardContentType clipboardContentType)
         {
+            // driver converts this content type to lower/upper properly on their side,
+            // but some environment might not work expected. Here sends upper case
+            // to cover https://github.com/appium/dotnet-client/issues/916
+            var contentType = clipboardContentType.ToString().ToUpper();
             switch (clipboardContentType)
             {
                 case ClipboardContentType.Image:
@@ -118,15 +127,12 @@ namespace OpenQA.Selenium.Appium
                         throw new NotImplementedException(
                             $"Android only supports contentType: {nameof(ClipboardContentType.PlainText)}");
                     }
-
                     return (string) executeMethod.Execute(AppiumDriverCommand.GetClipboard,
-                        PrepareArgument("contentType", clipboardContentType.ToString().ToLower())).Value;
-                case ClipboardContentType.PlainText:
-                    return (string) executeMethod.Execute(AppiumDriverCommand.GetClipboard,
-                        PrepareArgument("contentType", clipboardContentType.ToString().ToLower())).Value;
+                        PrepareArgument("contentType", contentType)).Value;
                 default:
+                    // including ClipboardContentType.PlainText
                     return (string) executeMethod.Execute(AppiumDriverCommand.GetClipboard,
-                        PrepareArgument("contentType", clipboardContentType.ToString().ToLower())).Value;
+                        PrepareArgument("contentType", contentType)).Value;
             }
         }
 
@@ -144,7 +150,10 @@ namespace OpenQA.Selenium.Appium
                     new object[]
                     {
                         Convert.ToBase64String(encodedStringContentBytes),
-                        ClipboardContentType.PlainText.ToString().ToLower(), label
+                        // driver converts this content type to lower/upper properly on their side,
+                        // but some environment might not work expected. Here sends upper case
+                        // to cover https://github.com/appium/dotnet-client/issues/916
+                        ClipboardContentType.PlainText.ToString().ToUpper(), label
                     })).Value;
         }
 


### PR DESCRIPTION
## List of changes

Fixes https://github.com/appium/dotnet-client/issues/916

ToLower/ToUpper reflects the host language config, so we must use ToLowerInvariant/ToUpperInvariant to avoid the issue

## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [x] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Please provide more details about changes if necessary. You can provide code samples showing how they work and possible use cases if there are new features. Also, you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://docs.github.com/en/get-started/writing-on-github)
