### PR TITLE
fix: Use correct parameter for appium-xcuitest-driver "mobile: installApp"

### DIFF
--- a/src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs
@@ -99,14 +99,14 @@ namespace OpenQA.Selenium.Appium.iOS
         /// For documentation, see <see href="https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-installapp">mobile: installApp</see>.
         /// </summary>
         /// <param name="executeMethod">The execute method</param>
-        /// <param name="appPath">Full path to the .ipa on the local filesystem or a remote URL.</param>
+        /// <param name="app">Full path to the .ipa on the local filesystem or a remote URL.</param>
         /// <param name="timeoutMs">Optional timeout in milliseconds to wait for the app installation to complete.</param>
         public static void InstallApp(
             IExecuteMethod executeMethod, 
-            string appPath, 
+            string app, 
             int? timeoutMs = null)
         {
-            var args = new Dictionary<string, object> { { "appPath", appPath } };
+            var args = new Dictionary<string, object> { { "app", app } };
             
             if (timeoutMs.HasValue)
                 args["timeoutMs"] = timeoutMs.Value;

--- a/src/Appium.Net/Appium/iOS/IOSDriver.cs
+++ b/src/Appium.Net/Appium/iOS/IOSDriver.cs
@@ -206,10 +206,10 @@ namespace OpenQA.Selenium.Appium.iOS
         /// Install an app on the iOS device using mobile: installApp script.
         /// For documentation, see <see href="https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-installapp">mobile: installApp</see>.
         /// </summary>
-        /// <param name="appPath">Full path to the .ipa on the local filesystem or a remote URL.</param>
+        /// <param name="app">Full path to the .ipa on the local filesystem or a remote URL.</param>
         /// <param name="timeoutMs">Optional timeout in milliseconds to wait for the app installation to complete.</param>
-        public void InstallApp(string appPath, int? timeoutMs = null) =>
-            IOSCommandExecutionHelper.InstallApp(this, appPath, timeoutMs);
+        public void InstallApp(string app, int? timeoutMs = null) =>
+            IOSCommandExecutionHelper.InstallApp(this, app, timeoutMs);
 
         /// <summary>
         /// Launch an app on the iOS device using mobile: launchApp script.


### PR DESCRIPTION
## List of changes

Change "appPath" to "app" in src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs and src/Appium.Net/Appium/iOS/IOSDriver.cs
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

As per xcuitet-driver documentation [here](https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-installapp) the execute method takes "app" as an argument, not "appPath".

Changed "appPath" for installing Apps for iOS to "app".
