### PR TITLE
fix(test): correct pointer move offset and add transition wait in SimpleTouchActionTestCase

### DIFF
--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -69,7 +69,7 @@ namespace Appium.Net.Integration.Tests.Android
                 WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
                 return wait.Until(d =>
                 {
-                    var els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+                    var els = ((AndroidDriver)d).FindElements(MobileBy.ClassName("android.widget.TextView"));
                     return els.Count >= minimumCount ? els : null;
                 });
             }
@@ -124,7 +124,7 @@ namespace Appium.Net.Integration.Tests.Android
                 WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
                 els = wait.Until(d =>
                 {
-                    var currentEls = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+                    var currentEls = ((AndroidDriver)d).FindElements(MobileBy.ClassName("android.widget.TextView"));
                     return currentEls.Count != number1 ? currentEls : null;
                 });
             }

--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -122,12 +122,11 @@ namespace Appium.Net.Integration.Tests.Android
             try
             {
                 WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
-                var countChanged = wait.Until(d =>
+                wait.Until(d =>
                 {
                     var currentEls = d.FindElements(MobileBy.ClassName("android.widget.TextView"));
                     return currentEls.Count != number1;
                 });
-                Assert.That(countChanged, Is.True);
             }
             finally
             {

--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -100,7 +100,7 @@ namespace Appium.Net.Integration.Tests.Android
             var touch = new PointerInputDevice(PointerKind.Touch, "finger");
             var sequence = new ActionSequence(touch);
 
-            var move = touch.CreatePointerMove(elementToTouch, elementToTouch.Location.X, elementToTouch.Location.Y,TimeSpan.FromSeconds(1));
+            var move = touch.CreatePointerMove(elementToTouch, 0, 0, TimeSpan.FromSeconds(1));
             var actionPress = touch.CreatePointerDown(PointerButton.TouchContact);
             var pause = touch.CreatePause(TimeSpan.FromMilliseconds(250));
             var actionRelease = touch.CreatePointerUp(PointerButton.TouchContact);
@@ -117,9 +117,22 @@ namespace Appium.Net.Integration.Tests.Android
 
             _driver.PerformActions(actions_seq);
 
-            els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
-
-            Assert.That(els, Has.Count.Not.EqualTo(number1));
+            var previousImplicitWait = _driver.Manage().Timeouts().ImplicitWait;
+            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+            try
+            {
+                WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
+                var countChanged = wait.Until(d =>
+                {
+                    var currentEls = d.FindElements(MobileBy.ClassName("android.widget.TextView"));
+                    return currentEls.Count != number1;
+                });
+                Assert.That(countChanged, Is.True);
+            }
+            finally
+            {
+                _driver.Manage().Timeouts().ImplicitWait = previousImplicitWait;
+            }
         }
 
         [Test]

--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -122,16 +122,18 @@ namespace Appium.Net.Integration.Tests.Android
             try
             {
                 WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
-                wait.Until(d =>
+                els = wait.Until(d =>
                 {
-                    var currentEls = d.FindElements(MobileBy.ClassName("android.widget.TextView"));
-                    return currentEls.Count != number1;
+                    var currentEls = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+                    return currentEls.Count != number1 ? currentEls : null;
                 });
             }
             finally
             {
                 _driver.Manage().Timeouts().ImplicitWait = previousImplicitWait;
             }
+
+            Assert.That(els, Has.Count.Not.EqualTo(number1));
         }
 
         [Test]


### PR DESCRIPTION
## PR title

fix(test): correct pointer move offset and add transition wait in SimpleTouchActionTestCase

## Related issue

n/a

## List of changes

- Fixed `SimpleTouchActionTestCase` in `test/integration/Android/ActionsChainsTest.cs` by changing `CreatePointerMove(elementToTouch, ...)` offset from absolute screen coordinates `(elementToTouch.Location.X, elementToTouch.Location.Y)` to `(0, 0)` relative to the element origin.
- Added explicit `WebDriverWait` to wait for view transition / element count change before asserting, eliminating CI race condition / flakiness.

## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **New test coverage** (non-breaking change that adds tests for existing, previously untested functionality)
- [x] Test fix (non-breaking change that improves test stability or correctness)
- [ ] Chore/Maintenance (updates to build scripts, dependencies, or GitHub Actions)

## Tests

_Put an `x` in the boxes that apply_

- [ ] Unit tests
- [x] Integration tests
- [ ] No automated tests (explain why below)

**How they run:** Picked up by the existing `FullyQualifiedName~Android` functional test filter in CI.

## Documentation
- [ ] Have you proposed a file change/PR with Appium to update documentation?
- [x] Not applicable (no user-facing behaviour change, e.g. tests, CI or maintenance only)

## Details

In W3C actions / Selenium .NET, `touch.CreatePointerMove(elementToTouch, offsetX, offsetY, duration)` accepts offsets that are relative to the target element's center/origin. Passing `elementToTouch.Location.X` and `elementToTouch.Location.Y` (absolute screen coordinates) resulted in the touch pointer being moved hundreds of pixels away from the element into dead space or unintended elements.

Additionally, after calling `_driver.PerformActions()`, the test was querying `FindElements` immediately without waiting for screen transition animations to settle. Adding an explicit `WebDriverWait` ensures the test stably awaits the screen state change.
