### PR TITLE
chore: optimize extraction of Contexts and IME engines

### DIFF
--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -339,15 +339,14 @@ namespace OpenQA.Selenium.Appium
             get
             {
                 var commandResponse = ((IExecuteMethod)this).Execute(AppiumDriverCommand.Contexts);
-                var contexts = new List<string>();
                 var objects = commandResponse.Value as object[];
 
-                if (null != objects && 0 < objects.Length)
+                if (objects == null || objects.Length == 0)
                 {
-                    contexts.AddRange(objects.Select(o => o.ToString()));
+                    return Array.AsReadOnly(Array.Empty<string>());
                 }
 
-                return contexts.AsReadOnly();
+                return Array.AsReadOnly(Array.ConvertAll(objects, o => o.ToString()));
             }
         }
 
@@ -380,15 +379,21 @@ namespace OpenQA.Selenium.Appium
         /// <returns>List of available </returns>
         public List<string> GetIMEAvailableEngines()
         {
-            var retVal = new List<string>();
             var commandResponse = ((IExecuteMethod)this).Execute(AppiumDriverCommand.GetAvailableEngines);
             var objectArr = commandResponse.Value as object[];
-            if (null != objectArr)
+
+            if (objectArr == null)
             {
-                retVal.AddRange(objectArr.Select(val => val.ToString()));
+                return new List<string>();
             }
 
-            return retVal;
+            var engines = new List<string>(objectArr.Length);
+            foreach (var val in objectArr)
+            {
+                engines.Add(val.ToString());
+            }
+
+            return engines;
         }
 
         /// <summary>


### PR DESCRIPTION
## Related issue

Closes # n/a

## List of changes

- Refactored `AppiumDriver.Contexts` to use `Array.ConvertAll` and `Array.AsReadOnly`, eliminating LINQ iterator allocation and redundant list wrappers.
- Handled null or empty response in `Contexts` by returning `Array.AsReadOnly(Array.Empty<string>())`.
- Pre-sized `List<string>` in `GetIMEAvailableEngines` to avoid repeated backing array resizing.
- Replaced Yoda conditions (`null != objects`) with standard C# null and length checks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **New test coverage** (non-breaking change that adds tests for existing, previously untested functionality)
- [ ] Test fix (non-breaking change that improves test stability or correctness)
- [x] Chore/Maintenance (updates to build scripts, dependencies, or GitHub Actions)

## Tests

- [ ] Unit tests
- [x] Integration tests
- [ ] No automated tests (explain why below)

**How they run:** Covered by existing integration tests (`ImeTest.cs`, `WebviewTest.cs`). Verified local build passes with zero errors.

## Documentation
- [ ] Have you proposed a file change/PR with Appium to update documentation?
- [x] Not applicable (no user-facing behaviour change, e.g. tests, CI or maintenance only)

## Details

This change modernizes context and IME engine extraction to avoid unnecessary heap allocations:
- The previous implementation used `Select(o => o.ToString())` inside `List.AddRange(...)`. Because LINQ's `Select` returns an iterator without count information, `AddRange` defaults to incremental array resizing.
- In `Contexts`, using `Array.ConvertAll` transforms the deserialized object array directly into `string[]` in a single pass with the exact capacity needed, and `Array.AsReadOnly(...)` wraps it without allocating an intermediate `List<string>`.
- In `GetIMEAvailableEngines`, initializing `new List<string>(objectArr.Length)` ensures the backing buffer is allocated once.
