### PR TITLE
chore: support refactor label and PR template category

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## PR title
 
 The title is what gets labelled: `.github/labeler.yml` matches the title and applies a label, and Release Drafter turns that label into a release-notes category and the version bump. Please prefix the title with the matching type:
-`feat:` (new feature) · `fix:` (bugfix) · `test:` · `docs:` · `build:` · `ci:` · `chore:` · `github:`
+`feat:` (new feature) · `fix:` (bugfix) · `refactor:` · `test:` · `docs:` · `build:` · `ci:` · `chore:` · `github:`
 A scope is optional, e.g. `feat(ios):`. Breaking changes use `type!:` (`feat!:`, `feat(ios)!:`) or carry `BREAKING CHANGE:` in the title.
 
 ## Related issue
@@ -19,6 +19,7 @@ _Put an `x` in the boxes that apply_
 
 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality or value)
+- [ ] Refactoring (non-breaking change that improves code without altering functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
 - [ ] **New test coverage** (non-breaking change that adds tests for existing, previously untested functionality)
 - [ ] Test fix (non-breaking change that improves test stability or correctness)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,9 @@ Enhancement:
 BugFix:
   title: '^fix(\([^)]+\))?!?:.*'
 
+Refactor:
+  title: '^refactor(\([^)]+\))?!?:.*'
+
 Documentation:
   title: '^docs(\([^)]+\))?!?:.*'
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,3 +60,9 @@ version-resolver:
   
 prerelease: false
 contribution-template: '- $NAME contributed via $PULL_REQUEST'
+exclude-contributors:
+  - 'dependabot[bot]'
+  - 'dependabot'
+  - 'github-actions[bot]'
+  - 'copilot-swe-agent[bot]'
+  - 'claude'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,6 +20,7 @@ categories:
       labels:
         - 'BugFix'
   - title: '🔄 Refactor'
+    semver-increment: 'patch'
     when:
       label: 'Refactor'
   - title: '📦 Dependencies'


### PR DESCRIPTION
## PR title

`chore: support refactor label, PR template category, and bot exclusion`

## Related issue

Closes # n/a

## List of changes

- Add `Refactor` pattern (`^refactor(\([^)]+\))?!?:.*`) to `.github/labeler.yml` so PRs prefixed with `refactor:` automatically receive the `Refactor` label.
- Add explicit `semver-increment: 'patch'` to the `Refactor` category in `.github/release-drafter.yml`.
- Add `exclude-contributors` list to `.github/release-drafter.yml` to filter out bots (`dependabot[bot]`, `github-actions[bot]`, `copilot-swe-agent[bot]`) and AI co-author handles (`claude`) from the `$CONTRIBUTORS` section.
- Add `refactor:` prefix and a `Refactoring` checkbox in `.github/PULL_REQUEST_TEMPLATE.md`.

## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Refactoring (non-breaking change that improves code without altering functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **New test coverage** (non-breaking change that adds tests for existing, previously untested functionality)
- [ ] Test fix (non-breaking change that improves test stability or correctness)
- [x] Chore/Maintenance (updates to build scripts, dependencies, or GitHub Actions)

## Tests

_Put an `x` in the boxes that apply_

- [ ] Unit tests
- [ ] Integration tests
- [x] No automated tests (explain why below)

**How they run:** Configuration and template changes only; validated YAML syntax locally.

## Documentation
- [ ] Have you proposed a file change/PR with Appium to update documentation?
- [x] Not applicable (no user-facing behaviour change, e.g. tests, CI or maintenance only)

## Details

1. Previously, `.github/release-drafter.yml` included a `Refactor` category, but `.github/labeler.yml` lacked a corresponding rule for `refactor:` titles. As a result, refactoring PRs (such as #1103) were never labelled `Refactor` and were placed outside of any category in drafted release notes. This change ensures refactor PRs are properly labelled and categorized going forward.
2. Configured `exclude-contributors` in `.github/release-drafter.yml` so bots and AI co-author handles are automatically excluded from the drafted `$CONTRIBUTORS` section, matching past release conventions without requiring manual trimming.
